### PR TITLE
Link Code Images logo to editor and add feature banner

### DIFF
--- a/components/code-image/CodeImageEditor.tsx
+++ b/components/code-image/CodeImageEditor.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { domToBlob } from 'modern-screenshot';
 import { toast } from 'sonner';
 import {
@@ -109,14 +110,20 @@ const TopBar = React.memo(function TopBar({
   return (
     <header className="flex h-[50px] shrink-0 items-center justify-between gap-3 border-b border-white/[0.06] px-4">
       <div className="flex items-center gap-2">
-        <Image
-          src="/logo-mark.png"
-          alt="Screenshot Studio"
-          width={28}
-          height={28}
-          className="h-7 w-7 shrink-0"
-          priority
-        />
+        <Link
+          href="/"
+          aria-label="Open Screenshot Studio editor"
+          className="shrink-0 transition-opacity hover:opacity-80"
+        >
+          <Image
+            src="/logo-mark.png"
+            alt="Screenshot Studio"
+            width={28}
+            height={28}
+            className="h-7 w-7"
+            priority
+          />
+        </Link>
         <span className="text-sm font-medium text-white/90">Code Images</span>
         <span className="hidden text-xs text-white/40 sm:inline">
           by Screenshot Studio

--- a/components/editor/CodeImagesBanner.tsx
+++ b/components/editor/CodeImagesBanner.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { ArrowRight01Icon, Cancel01Icon, SourceCodeIcon } from "hugeicons-react";
+
+const DISMISSED_KEY = "screenshotstudio-code-images-banner-dismissed";
+
+export function CodeImagesBanner() {
+  const isMobile = useIsMobile();
+  const [isDismissed, setIsDismissed] = React.useState(true);
+
+  React.useEffect(() => {
+    setIsDismissed(localStorage.getItem(DISMISSED_KEY) === "true");
+  }, []);
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, "true");
+    setIsDismissed(true);
+  };
+
+  if (isMobile || isDismissed) return null;
+
+  return (
+    <div className="relative z-50 w-full border-b border-foreground/10 bg-card px-4 py-2">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span className="inline-flex h-6 items-center rounded-full bg-foreground px-2 text-[10px] font-semibold uppercase tracking-wide text-background">
+            New
+          </span>
+          <SourceCodeIcon size={16} className="shrink-0 text-foreground" />
+          <p className="truncate text-sm text-foreground">
+            <span className="font-medium">Code Images</span>
+            <span className="text-muted-foreground">
+              {" "}turns any snippet into a beautiful shareable image with 14 themes and 150+ backgrounds.
+            </span>
+          </p>
+          <Link
+            href="/code"
+            className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-foreground underline-offset-4 hover:underline"
+          >
+            Try it
+            <ArrowRight01Icon size={14} />
+          </Link>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Cancel01Icon size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/editor/EditorLayout.tsx
+++ b/components/editor/EditorLayout.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Settings02Icon, VideoReplayIcon } from "hugeicons-react";
 import { useAutosaveDraft } from "@/hooks/useAutosaveDraft";
 import { MobileBanner } from "./MobileBanner";
+import { CodeImagesBanner } from "./CodeImagesBanner";
 import { TimelineEditor } from "@/components/timeline";
 import { useImageStore } from "@/lib/store";
 import { trackEditorOpen } from "@/lib/analytics";
@@ -64,6 +65,7 @@ function EditorMain() {
       <EditorStoreSync />
 
       <MobileBanner />
+      <CodeImagesBanner />
 
       <EditorHeader />
 


### PR DESCRIPTION
- Logo in the /code top bar now links to the main editor (/)
- Dismissible "New: Code Images" banner in the editor (desktop only, localStorage dismiss, links to /code)