### PR TITLE
feat: 3D tilt, shadow and corner radius for image overlays; list main image in Layers

### DIFF
--- a/components/canvas/html/HTMLImageOverlayLayer.tsx
+++ b/components/canvas/html/HTMLImageOverlayLayer.tsx
@@ -81,7 +81,7 @@ function OverlayElement({
     overlay.flipX ? 'scaleX(-1)' : '',
     overlay.flipY ? 'scaleY(-1)' : '',
   ].filter(Boolean).join(' ');
-  const fitted = fitOverlayImage(overlay.size, overlayImg.naturalWidth, overlayImg.naturalHeight);
+  const fitted = fitOverlayImage(overlayImg.naturalWidth, overlayImg.naturalHeight);
 
   return (
     <div
@@ -114,10 +114,8 @@ function OverlayElement({
         alt="Overlay"
         draggable={false}
         style={{
-          width: `${fitted.width}px`,
-          height: `${fitted.height}px`,
-          maxWidth: '100%',
-          maxHeight: '100%',
+          width: `${fitted.width}%`,
+          height: `${fitted.height}%`,
           objectFit: 'contain',
           display: 'block',
           borderRadius: overlay.radius ? `${overlay.radius}px` : undefined,

--- a/components/canvas/html/HTMLImageOverlayLayer.tsx
+++ b/components/canvas/html/HTMLImageOverlayLayer.tsx
@@ -5,6 +5,12 @@ import Moveable from 'react-moveable';
 import type { ImageOverlay } from '@/lib/store';
 import { cn } from '@/lib/utils';
 import {
+  buildOverlayShadowFilter,
+  buildOverlayTiltTransform,
+  fitOverlayImage,
+  hasOverlayTilt,
+} from '@/lib/overlay-style';
+import {
   Delete02Icon,
   Copy01Icon,
   LayerSendToBackIcon,
@@ -70,10 +76,12 @@ function OverlayElement({
     );
   }
 
-  const flipTransform = [
+  const imageTransform = [
+    buildOverlayTiltTransform(overlay.tilt),
     overlay.flipX ? 'scaleX(-1)' : '',
     overlay.flipY ? 'scaleY(-1)' : '',
   ].filter(Boolean).join(' ');
+  const fitted = fitOverlayImage(overlay.size, overlayImg.naturalWidth, overlayImg.naturalHeight);
 
   return (
     <div
@@ -89,7 +97,11 @@ function OverlayElement({
         top: `${overlay.position.y - overlay.size / 2}px`,
         width: `${overlay.size}px`,
         height: `${overlay.size}px`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         transform: `rotate(${overlay.rotation}deg)`,
+        perspective: hasOverlayTilt(overlay.tilt) ? `${overlay.tilt.perspective}px` : undefined,
         opacity: overlay.opacity,
         filter: (overlay.blur ?? 0) > 0 ? `blur(${overlay.blur}px)` : undefined,
         cursor: 'grab',
@@ -102,11 +114,15 @@ function OverlayElement({
         alt="Overlay"
         draggable={false}
         style={{
-          width: '100%',
-          height: '100%',
+          width: `${fitted.width}px`,
+          height: `${fitted.height}px`,
+          maxWidth: '100%',
+          maxHeight: '100%',
           objectFit: 'contain',
           display: 'block',
-          transform: flipTransform || undefined,
+          borderRadius: overlay.radius ? `${overlay.radius}px` : undefined,
+          filter: buildOverlayShadowFilter(overlay.shadow),
+          transform: imageTransform || undefined,
           pointerEvents: 'none',
         }}
       />

--- a/components/canvas/html/HTMLImageOverlayLayer.tsx
+++ b/components/canvas/html/HTMLImageOverlayLayer.tsx
@@ -322,6 +322,7 @@ export function HTMLImageOverlayLayer({
 
           {!interacting && (
             <div
+              data-export-exclude="true"
               style={{
                 position: 'absolute',
                 left: `${selectedOverlay.position.x - selectedOverlay.size / 2}px`,

--- a/components/canvas/html/HTMLMainImageLayer.tsx
+++ b/components/canvas/html/HTMLMainImageLayer.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState, useCallback, useMemo, useEffect } from 'react';
 import { type ShadowConfig } from '../utils/shadow-utils';
+import { buildDropShadowFilter as buildSharedDropShadowFilter, parseShadowRgb } from '@/lib/drop-shadow';
 import { type ImageFilters, useImageStore } from '@/lib/store';
 import { SafariToolbar, ChromeToolbar } from '../frames/BrowserToolbar';
 import { CanvasObjectTopControls } from './CanvasObjectTopControls';
@@ -86,47 +87,16 @@ function buildImageFilter(imageFilters?: ImageFilters): string | undefined {
   return filters.length > 0 ? filters.join(' ') : undefined;
 }
 
-/**
- * Builds a CSS `filter: drop-shadow()` string.
- *
- * ShadowConfig fields (synced from imageShadow):
- * - softness → blur radius (from imageShadow.blur)
- * - offsetX/Y → shadow offset (direct from imageShadow)
- * - intensity → opacity (from imageShadow.opacity)
- * - color → shadow color (direct from imageShadow)
- */
 function buildDropShadowFilter(shadow: ShadowConfig): string | undefined {
   if (!shadow.enabled) return undefined;
-
-  const { softness, spread, color, intensity, offsetX, offsetY } = shadow;
-
-  // Parse shadow color — use it directly
-  let r = 0, g = 0, b = 0;
-  const colorMatch = color.match(/rgba?\(([^)]+)\)/);
-
-  if (colorMatch) {
-    const parts = colorMatch[1].split(',').map(s => s.trim());
-    r = parseInt(parts[0]) || 0;
-    g = parseInt(parts[1]) || 0;
-    b = parseInt(parts[2]) || 0;
-  } else if (color.startsWith('#')) {
-    const hex = color.replace('#', '');
-    r = parseInt(hex.slice(0, 2), 16) || 0;
-    g = parseInt(hex.slice(2, 4), 16) || 0;
-    b = parseInt(hex.slice(4, 6), 16) || 0;
-  }
-
-  const x = offsetX ?? 0;
-  const y = offsetY ?? 0;
-  // Blur from the blur slider; spread adds extra diffusion
-  const blur = softness + (spread || 0);
-  const opacity = Math.min(1, Math.max(0, intensity));
-
-  // Two-layer shadow: key shadow + soft ambient fill
-  return [
-    `drop-shadow(${x}px ${y}px ${blur}px rgba(${r}, ${g}, ${b}, ${opacity}))`,
-    `drop-shadow(0px 0px ${blur * 0.5}px rgba(${r}, ${g}, ${b}, ${opacity * 0.2}))`,
-  ].join(' ');
+  return buildSharedDropShadowFilter({
+    blur: shadow.softness,
+    spread: shadow.spread || 0,
+    color: shadow.color,
+    opacity: shadow.intensity,
+    offsetX: shadow.offsetX ?? 0,
+    offsetY: shadow.offsetY ?? 0,
+  });
 }
 
 /**
@@ -138,21 +108,7 @@ function buildBoxShadow(shadow: ShadowConfig): string | undefined {
   if (!shadow.enabled) return undefined;
 
   const { softness, spread, color, intensity, offsetX, offsetY } = shadow;
-
-  let r = 0, g = 0, b = 0;
-  const colorMatch = color.match(/rgba?\(([^)]+)\)/);
-
-  if (colorMatch) {
-    const parts = colorMatch[1].split(',').map(s => s.trim());
-    r = parseInt(parts[0]) || 0;
-    g = parseInt(parts[1]) || 0;
-    b = parseInt(parts[2]) || 0;
-  } else if (color.startsWith('#')) {
-    const hex = color.replace('#', '');
-    r = parseInt(hex.slice(0, 2), 16) || 0;
-    g = parseInt(hex.slice(2, 4), 16) || 0;
-    b = parseInt(hex.slice(4, 6), 16) || 0;
-  }
+  const [r, g, b] = parseShadowRgb(color);
 
   const x = offsetX ?? 0;
   const y = offsetY ?? 0;

--- a/components/editor/sections/DepthSection.tsx
+++ b/components/editor/sections/DepthSection.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useImageStore } from '@/lib/store';
-import type { ImageOverlay } from '@/lib/store';
+import type { ImageOverlay, ImageOverlayTilt, ImageShadow } from '@/lib/store';
 import { SectionWrapper } from './SectionWrapper';
 import { cn } from '@/lib/utils';
 import { Slider } from '@/components/ui/slider';
@@ -663,7 +663,7 @@ function OverlayCornerRadiusControls({ overlay, onUpdate }: OverlayControlProps)
 
 function OverlayTiltControls({ overlay, onUpdate }: OverlayControlProps) {
   const tilt = overlay.tilt ?? DEFAULT_OVERLAY_TILT;
-  const setTilt = (updates: Partial<ImageOverlay['tilt']>) =>
+  const setTilt = (updates: Partial<ImageOverlayTilt>) =>
     onUpdate({ tilt: { ...tilt, ...updates } });
 
   return (
@@ -696,30 +696,21 @@ function OverlayTiltControls({ overlay, onUpdate }: OverlayControlProps) {
         valueDisplay={`${tilt.rotateY}°`}
       />
       <Slider
-        value={[tilt.rotateZ]}
-        onValueChange={(v) => setTilt({ rotateZ: v[0] })}
-        min={-45}
-        max={45}
-        step={1}
-        label="Rotate Z"
-        valueDisplay={`${tilt.rotateZ}°`}
-      />
-      <Slider
         value={[tilt.perspective]}
         onValueChange={(v) => setTilt({ perspective: v[0] })}
         min={50}
         max={1000}
         step={10}
         label="Perspective"
-        valueDisplay={`${tilt.perspective}`}
+        valueDisplay={`${tilt.perspective}px`}
       />
     </div>
   );
 }
 
 function OverlayShadowControls({ overlay, onUpdate }: OverlayControlProps) {
-  const shadow = overlay.shadow ?? { ...DEFAULT_OVERLAY_SHADOW, enabled: false };
-  const setShadow = (updates: Partial<ImageOverlay['shadow']>) =>
+  const shadow = overlay.shadow ?? DEFAULT_OVERLAY_SHADOW;
+  const setShadow = (updates: Partial<ImageShadow>) =>
     onUpdate({ shadow: { ...shadow, ...updates } });
 
   return (

--- a/components/editor/sections/DepthSection.tsx
+++ b/components/editor/sections/DepthSection.tsx
@@ -6,6 +6,8 @@ import type { ImageOverlay } from '@/lib/store';
 import { SectionWrapper } from './SectionWrapper';
 import { cn } from '@/lib/utils';
 import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import { DEFAULT_OVERLAY_SHADOW, DEFAULT_OVERLAY_TILT } from '@/lib/overlay-style';
 import { getR2ImageUrl } from '@/lib/r2';
 import { getOverlayUrl } from '@/lib/r2-overlays';
 import { isOverlayPath } from '@/lib/r2-overlays';
@@ -75,6 +77,8 @@ interface LayerItem {
 
 export function DepthSection() {
   const {
+    uploadedImageUrl,
+    imageName,
     imageOverlays,
     textOverlays,
     annotations,
@@ -252,14 +256,14 @@ export function DepthSection() {
         title="Layers"
         defaultOpen={true}
         action={
-          layers.length > 0 ? (
+          layers.length + (uploadedImageUrl ? 1 : 0) > 0 ? (
             <span className="text-[10px] tabular-nums text-muted-foreground">
-              {layers.length}
+              {layers.length + (uploadedImageUrl ? 1 : 0)}
             </span>
           ) : undefined
         }
       >
-        {layers.length === 0 ? (
+        {layers.length === 0 && !uploadedImageUrl ? (
           <div className="flex flex-col items-center gap-2 py-6 text-center">
             <LayersLogoIcon size={28} className="text-muted-foreground/50" />
             <p className="text-xs text-muted-foreground">
@@ -405,6 +409,27 @@ export function DepthSection() {
                 </div>
               );
             })}
+            {uploadedImageUrl && (
+              <div
+                className="flex items-center gap-2.5 px-2.5 py-2 rounded-md"
+                title="Main image"
+              >
+                <div className="w-9 h-9 rounded-md flex items-center justify-center shrink-0 overflow-hidden bg-foreground/[0.06] border border-foreground/10">
+                  <img
+                    src={uploadedImageUrl}
+                    alt=""
+                    draggable={false}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium text-foreground truncate">
+                    {imageName || 'Main image'}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">Main image · edit in the Edit tab</p>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </SectionWrapper>
@@ -574,6 +599,10 @@ function OverlayProperties({
         </button>
       </div>
 
+      <OverlayCornerRadiusControls overlay={overlay} onUpdate={onUpdate} />
+      <OverlayTiltControls overlay={overlay} onUpdate={onUpdate} />
+      <OverlayShadowControls overlay={overlay} onUpdate={onUpdate} />
+
       <div className="space-y-1.5">
         <span className="text-xs font-medium text-muted-foreground">Position</span>
         <div className="flex gap-1.5">
@@ -609,6 +638,140 @@ function OverlayProperties({
         <Delete02Icon size={14} />
         Remove
       </button>
+    </div>
+  );
+}
+
+interface OverlayControlProps {
+  overlay: ImageOverlay;
+  onUpdate: (updates: Partial<ImageOverlay>) => void;
+}
+
+function OverlayCornerRadiusControls({ overlay, onUpdate }: OverlayControlProps) {
+  return (
+    <Slider
+      value={[overlay.radius ?? 0]}
+      onValueChange={(v) => onUpdate({ radius: v[0] })}
+      min={0}
+      max={100}
+      step={1}
+      label="Corner radius"
+      valueDisplay={`${overlay.radius ?? 0}px`}
+    />
+  );
+}
+
+function OverlayTiltControls({ overlay, onUpdate }: OverlayControlProps) {
+  const tilt = overlay.tilt ?? DEFAULT_OVERLAY_TILT;
+  const setTilt = (updates: Partial<ImageOverlay['tilt']>) =>
+    onUpdate({ tilt: { ...tilt, ...updates } });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">3D Tilt</span>
+        <button
+          onClick={() => onUpdate({ tilt: undefined })}
+          className="flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors border border-foreground/10"
+        >
+          <RefreshIcon size={11} /> Reset
+        </button>
+      </div>
+      <Slider
+        value={[tilt.rotateX]}
+        onValueChange={(v) => setTilt({ rotateX: v[0] })}
+        min={-45}
+        max={45}
+        step={1}
+        label="Rotate X"
+        valueDisplay={`${tilt.rotateX}°`}
+      />
+      <Slider
+        value={[tilt.rotateY]}
+        onValueChange={(v) => setTilt({ rotateY: v[0] })}
+        min={-45}
+        max={45}
+        step={1}
+        label="Rotate Y"
+        valueDisplay={`${tilt.rotateY}°`}
+      />
+      <Slider
+        value={[tilt.rotateZ]}
+        onValueChange={(v) => setTilt({ rotateZ: v[0] })}
+        min={-45}
+        max={45}
+        step={1}
+        label="Rotate Z"
+        valueDisplay={`${tilt.rotateZ}°`}
+      />
+      <Slider
+        value={[tilt.perspective]}
+        onValueChange={(v) => setTilt({ perspective: v[0] })}
+        min={50}
+        max={1000}
+        step={10}
+        label="Perspective"
+        valueDisplay={`${tilt.perspective}`}
+      />
+    </div>
+  );
+}
+
+function OverlayShadowControls({ overlay, onUpdate }: OverlayControlProps) {
+  const shadow = overlay.shadow ?? { ...DEFAULT_OVERLAY_SHADOW, enabled: false };
+  const setShadow = (updates: Partial<ImageOverlay['shadow']>) =>
+    onUpdate({ shadow: { ...shadow, ...updates } });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">Shadow</span>
+        <Switch
+          checked={shadow.enabled}
+          onCheckedChange={(enabled) => setShadow({ enabled })}
+          aria-label="Toggle overlay shadow"
+        />
+      </div>
+      {shadow.enabled && (
+        <>
+          <Slider
+            value={[shadow.blur]}
+            onValueChange={(v) => setShadow({ blur: v[0] })}
+            min={0}
+            max={60}
+            step={1}
+            label="Blur"
+            valueDisplay={`${shadow.blur}px`}
+          />
+          <Slider
+            value={[shadow.offsetX]}
+            onValueChange={(v) => setShadow({ offsetX: v[0] })}
+            min={-50}
+            max={50}
+            step={1}
+            label="Offset X"
+            valueDisplay={`${shadow.offsetX}px`}
+          />
+          <Slider
+            value={[shadow.offsetY]}
+            onValueChange={(v) => setShadow({ offsetY: v[0] })}
+            min={-50}
+            max={50}
+            step={1}
+            label="Offset Y"
+            valueDisplay={`${shadow.offsetY}px`}
+          />
+          <Slider
+            value={[shadow.opacity]}
+            onValueChange={(v) => setShadow({ opacity: v[0] })}
+            min={0}
+            max={1}
+            step={0.01}
+            label="Opacity"
+            valueDisplay={`${Math.round(shadow.opacity * 100)}%`}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/components/editor/sections/ImageOverlaySection.tsx
+++ b/components/editor/sections/ImageOverlaySection.tsx
@@ -17,7 +17,7 @@ function getThumbSrc(overlay: { src: string; isCustom?: boolean }) {
 }
 
 export function ImageOverlaySection() {
-  const { imageOverlays, textOverlays, annotations, blurRegions, setActiveRightPanelTab, addImageOverlay } =
+  const { uploadedImageUrl, imageOverlays, textOverlays, annotations, blurRegions, setActiveRightPanelTab, addImageOverlay } =
     useImageStore();
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -42,7 +42,7 @@ export function ImageOverlaySection() {
   }, [addImageOverlay]);
 
   const totalLayers =
-    imageOverlays.length + textOverlays.length + annotations.length + blurRegions.length;
+    (uploadedImageUrl ? 1 : 0) + imageOverlays.length + textOverlays.length + annotations.length + blurRegions.length;
 
   // Show up to 4 thumbnails from image overlays for the stacked preview
   const previewOverlays = imageOverlays.slice(-4);

--- a/lib/drop-shadow.ts
+++ b/lib/drop-shadow.ts
@@ -1,0 +1,40 @@
+export interface DropShadowInput {
+  blur: number;
+  spread: number;
+  color: string;
+  opacity: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+export function parseShadowRgb(color: string): [number, number, number] {
+  const functional = color.match(/rgba?\(([^)]+)\)/);
+  if (functional) {
+    const channels = functional[1]
+      .split("/")[0]
+      .split(/[\s,]+/)
+      .filter(Boolean)
+      .map((channel) => parseInt(channel, 10) || 0);
+    return [channels[0] ?? 0, channels[1] ?? 0, channels[2] ?? 0];
+  }
+  if (color.startsWith("#")) {
+    const hex = color.slice(1);
+    return [
+      parseInt(hex.slice(0, 2), 16) || 0,
+      parseInt(hex.slice(2, 4), 16) || 0,
+      parseInt(hex.slice(4, 6), 16) || 0,
+    ];
+  }
+  return [0, 0, 0];
+}
+
+export function buildDropShadowFilter(shadow: DropShadowInput): string {
+  const [r, g, b] = parseShadowRgb(shadow.color);
+  const blur = shadow.blur + shadow.spread;
+  const opacity = Math.min(1, Math.max(0, shadow.opacity));
+  const ambientOpacity = Math.round(opacity * 200) / 1000;
+  return [
+    `drop-shadow(${shadow.offsetX}px ${shadow.offsetY}px ${blur}px rgba(${r}, ${g}, ${b}, ${opacity}))`,
+    `drop-shadow(0px 0px ${blur * 0.5}px rgba(${r}, ${g}, ${b}, ${ambientOpacity}))`,
+  ].join(" ");
+}

--- a/lib/overlay-style.ts
+++ b/lib/overlay-style.ts
@@ -5,7 +5,6 @@ export const DEFAULT_OVERLAY_TILT: ImageOverlayTilt = {
   perspective: 200,
   rotateX: 0,
   rotateY: 0,
-  rotateZ: 0,
 };
 
 export const DEFAULT_OVERLAY_SHADOW: ImageShadow = {
@@ -19,12 +18,12 @@ export const DEFAULT_OVERLAY_SHADOW: ImageShadow = {
 };
 
 export function hasOverlayTilt(tilt: ImageOverlayTilt | undefined): tilt is ImageOverlayTilt {
-  return Boolean(tilt && (tilt.rotateX !== 0 || tilt.rotateY !== 0 || tilt.rotateZ !== 0));
+  return Boolean(tilt && (tilt.rotateX !== 0 || tilt.rotateY !== 0));
 }
 
 export function buildOverlayTiltTransform(tilt: ImageOverlayTilt | undefined): string | undefined {
   if (!hasOverlayTilt(tilt)) return undefined;
-  return `rotateX(${tilt.rotateX}deg) rotateY(${tilt.rotateY}deg) rotateZ(${tilt.rotateZ}deg)`;
+  return `rotateX(${tilt.rotateX}deg) rotateY(${tilt.rotateY}deg)`;
 }
 
 export function buildOverlayShadowFilter(shadow: ImageShadow | undefined): string | undefined {

--- a/lib/overlay-style.ts
+++ b/lib/overlay-style.ts
@@ -1,14 +1,15 @@
 import type { ImageOverlayTilt, ImageShadow } from "@/lib/store";
+import { buildDropShadowFilter } from "@/lib/drop-shadow";
 
 export const DEFAULT_OVERLAY_TILT: ImageOverlayTilt = {
-  perspective: 600,
+  perspective: 200,
   rotateX: 0,
   rotateY: 0,
   rotateZ: 0,
 };
 
 export const DEFAULT_OVERLAY_SHADOW: ImageShadow = {
-  enabled: true,
+  enabled: false,
   blur: 15,
   offsetX: 5,
   offsetY: 8,
@@ -26,38 +27,17 @@ export function buildOverlayTiltTransform(tilt: ImageOverlayTilt | undefined): s
   return `rotateX(${tilt.rotateX}deg) rotateY(${tilt.rotateY}deg) rotateZ(${tilt.rotateZ}deg)`;
 }
 
-function parseShadowRgb(color: string): [number, number, number] {
-  const rgbMatch = color.match(/rgba?\(([^)]+)\)/);
-  if (rgbMatch) {
-    const [r, g, b] = rgbMatch[1].split(",").map((part) => parseInt(part.trim(), 10) || 0);
-    return [r, g, b];
-  }
-  if (color.startsWith("#")) {
-    const hex = color.slice(1);
-    return [
-      parseInt(hex.slice(0, 2), 16) || 0,
-      parseInt(hex.slice(2, 4), 16) || 0,
-      parseInt(hex.slice(4, 6), 16) || 0,
-    ];
-  }
-  return [0, 0, 0];
-}
-
 export function buildOverlayShadowFilter(shadow: ImageShadow | undefined): string | undefined {
   if (!shadow?.enabled) return undefined;
-  const [r, g, b] = parseShadowRgb(shadow.color);
-  const blur = shadow.blur + shadow.spread;
-  const opacity = Math.min(1, Math.max(0, shadow.opacity));
-  return `drop-shadow(${shadow.offsetX}px ${shadow.offsetY}px ${blur}px rgba(${r}, ${g}, ${b}, ${opacity}))`;
+  return buildDropShadowFilter(shadow);
 }
 
 export function fitOverlayImage(
-  size: number,
   naturalWidth: number,
   naturalHeight: number
 ): { width: number; height: number } {
-  if (naturalWidth <= 0 || naturalHeight <= 0) return { width: size, height: size };
+  if (naturalWidth <= 0 || naturalHeight <= 0) return { width: 100, height: 100 };
   const aspect = naturalWidth / naturalHeight;
-  if (aspect >= 1) return { width: size, height: size / aspect };
-  return { width: size * aspect, height: size };
+  if (aspect >= 1) return { width: 100, height: 100 / aspect };
+  return { width: 100 * aspect, height: 100 };
 }

--- a/lib/overlay-style.ts
+++ b/lib/overlay-style.ts
@@ -1,0 +1,63 @@
+import type { ImageOverlayTilt, ImageShadow } from "@/lib/store";
+
+export const DEFAULT_OVERLAY_TILT: ImageOverlayTilt = {
+  perspective: 600,
+  rotateX: 0,
+  rotateY: 0,
+  rotateZ: 0,
+};
+
+export const DEFAULT_OVERLAY_SHADOW: ImageShadow = {
+  enabled: true,
+  blur: 15,
+  offsetX: 5,
+  offsetY: 8,
+  spread: 3,
+  color: "rgba(0, 0, 0, 0.6)",
+  opacity: 0.5,
+};
+
+export function hasOverlayTilt(tilt: ImageOverlayTilt | undefined): tilt is ImageOverlayTilt {
+  return Boolean(tilt && (tilt.rotateX !== 0 || tilt.rotateY !== 0 || tilt.rotateZ !== 0));
+}
+
+export function buildOverlayTiltTransform(tilt: ImageOverlayTilt | undefined): string | undefined {
+  if (!hasOverlayTilt(tilt)) return undefined;
+  return `rotateX(${tilt.rotateX}deg) rotateY(${tilt.rotateY}deg) rotateZ(${tilt.rotateZ}deg)`;
+}
+
+function parseShadowRgb(color: string): [number, number, number] {
+  const rgbMatch = color.match(/rgba?\(([^)]+)\)/);
+  if (rgbMatch) {
+    const [r, g, b] = rgbMatch[1].split(",").map((part) => parseInt(part.trim(), 10) || 0);
+    return [r, g, b];
+  }
+  if (color.startsWith("#")) {
+    const hex = color.slice(1);
+    return [
+      parseInt(hex.slice(0, 2), 16) || 0,
+      parseInt(hex.slice(2, 4), 16) || 0,
+      parseInt(hex.slice(4, 6), 16) || 0,
+    ];
+  }
+  return [0, 0, 0];
+}
+
+export function buildOverlayShadowFilter(shadow: ImageShadow | undefined): string | undefined {
+  if (!shadow?.enabled) return undefined;
+  const [r, g, b] = parseShadowRgb(shadow.color);
+  const blur = shadow.blur + shadow.spread;
+  const opacity = Math.min(1, Math.max(0, shadow.opacity));
+  return `drop-shadow(${shadow.offsetX}px ${shadow.offsetY}px ${blur}px rgba(${r}, ${g}, ${b}, ${opacity}))`;
+}
+
+export function fitOverlayImage(
+  size: number,
+  naturalWidth: number,
+  naturalHeight: number
+): { width: number; height: number } {
+  if (naturalWidth <= 0 || naturalHeight <= 0) return { width: size, height: size };
+  const aspect = naturalWidth / naturalHeight;
+  if (aspect >= 1) return { width: size, height: size / aspect };
+  return { width: size * aspect, height: size };
+}

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -69,6 +69,13 @@ export interface TextOverlay {
   textShadow: TextShadow;
 }
 
+export interface ImageOverlayTilt {
+  perspective: number;
+  rotateX: number;
+  rotateY: number;
+  rotateZ: number;
+}
+
 export interface ImageOverlay {
   id: string;
   src: string;
@@ -82,6 +89,9 @@ export interface ImageOverlay {
   isVisible: boolean;
   isCustom?: boolean; // Whether it's a custom uploaded overlay
   layer?: 'front' | 'back'; // Render in front of or behind the main image
+  tilt?: ImageOverlayTilt;
+  shadow?: ImageShadow;
+  radius?: number;
 }
 
 export interface BlurRegion {

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -73,7 +73,6 @@ export interface ImageOverlayTilt {
   perspective: number;
   rotateX: number;
   rotateY: number;
-  rotateZ: number;
 }
 
 export interface ImageOverlay {

--- a/tests/overlay-style.test.ts
+++ b/tests/overlay-style.test.ts
@@ -12,14 +12,14 @@ import {
 test("overlays without tilt keep rendering with no 3D transform", () => {
   assert.equal(hasOverlayTilt(undefined), false);
   assert.equal(buildOverlayTiltTransform(undefined), undefined);
-  assert.equal(buildOverlayTiltTransform({ perspective: 200, rotateX: 0, rotateY: 0, rotateZ: 0 }), undefined);
+  assert.equal(buildOverlayTiltTransform({ perspective: 200, rotateX: 0, rotateY: 0 }), undefined);
 });
 
 test("tilted overlays rotate around X then Y", () => {
-  const tilt = { perspective: 200, rotateX: 12, rotateY: -20, rotateZ: 0 };
+  const tilt = { perspective: 200, rotateX: 12, rotateY: -20 };
 
   assert.equal(hasOverlayTilt(tilt), true);
-  assert.equal(buildOverlayTiltTransform(tilt), "rotateX(12deg) rotateY(-20deg) rotateZ(0deg)");
+  assert.equal(buildOverlayTiltTransform(tilt), "rotateX(12deg) rotateY(-20deg)");
 });
 
 test("overlay shadows use the same drop-shadow as the main image", () => {

--- a/tests/overlay-style.test.ts
+++ b/tests/overlay-style.test.ts
@@ -1,72 +1,42 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildDropShadowFilter, parseShadowRgb } from "../lib/drop-shadow";
 import {
+  DEFAULT_OVERLAY_SHADOW,
   buildOverlayShadowFilter,
   buildOverlayTiltTransform,
   fitOverlayImage,
   hasOverlayTilt,
 } from "../lib/overlay-style";
 
-test("overlays without tilt render no 3D transform", () => {
-  assert.equal(buildOverlayTiltTransform(undefined), undefined);
-  assert.equal(
-    buildOverlayTiltTransform({ perspective: 600, rotateX: 0, rotateY: 0, rotateZ: 0 }),
-    undefined
-  );
-});
-
-test("tilted overlays render rotateX, rotateY and rotateZ in order", () => {
-  assert.equal(
-    buildOverlayTiltTransform({ perspective: 600, rotateX: 12, rotateY: -20, rotateZ: 3 }),
-    "rotateX(12deg) rotateY(-20deg) rotateZ(3deg)"
-  );
-});
-
-test("hasOverlayTilt is true only when some axis is rotated", () => {
+test("overlays without tilt keep rendering with no 3D transform", () => {
   assert.equal(hasOverlayTilt(undefined), false);
-  assert.equal(hasOverlayTilt({ perspective: 600, rotateX: 0, rotateY: 0, rotateZ: 0 }), false);
-  assert.equal(hasOverlayTilt({ perspective: 600, rotateX: 0, rotateY: 15, rotateZ: 0 }), true);
+  assert.equal(buildOverlayTiltTransform(undefined), undefined);
+  assert.equal(buildOverlayTiltTransform({ perspective: 200, rotateX: 0, rotateY: 0, rotateZ: 0 }), undefined);
 });
 
-test("disabled or missing shadows render no filter", () => {
-  assert.equal(buildOverlayShadowFilter(undefined), undefined);
-  assert.equal(
-    buildOverlayShadowFilter({
-      enabled: false,
-      blur: 15,
-      offsetX: 5,
-      offsetY: 8,
-      spread: 3,
-      color: "rgba(0, 0, 0, 0.6)",
-      opacity: 0.5,
-    }),
-    undefined
-  );
+test("tilted overlays rotate around X then Y", () => {
+  const tilt = { perspective: 200, rotateX: 12, rotateY: -20, rotateZ: 0 };
+
+  assert.equal(hasOverlayTilt(tilt), true);
+  assert.equal(buildOverlayTiltTransform(tilt), "rotateX(12deg) rotateY(-20deg) rotateZ(0deg)");
 });
 
-test("enabled shadows render a drop-shadow using blur plus spread and the shadow opacity", () => {
-  assert.equal(
-    buildOverlayShadowFilter({
-      enabled: true,
-      blur: 10,
-      offsetX: 4,
-      offsetY: 6,
-      spread: 2,
-      color: "#102030",
-      opacity: 0.4,
-    }),
-    "drop-shadow(4px 6px 12px rgba(16, 32, 48, 0.4))"
-  );
+test("overlay shadows use the same drop-shadow as the main image", () => {
+  const shadow = { ...DEFAULT_OVERLAY_SHADOW, enabled: true, color: "#102030" };
+
+  assert.equal(buildOverlayShadowFilter({ ...shadow, enabled: false }), undefined);
+  assert.equal(buildOverlayShadowFilter(shadow), buildDropShadowFilter(shadow));
 });
 
-test("landscape overlays fill the box width and keep their aspect ratio", () => {
-  assert.deepEqual(fitOverlayImage(200, 1600, 1000), { width: 200, height: 125 });
+test("shadow colors parse from hex, legacy rgba and modern space-separated rgb", () => {
+  assert.deepEqual(parseShadowRgb("#102030"), [16, 32, 48]);
+  assert.deepEqual(parseShadowRgb("rgba(0, 0, 0, 0.6)"), [0, 0, 0]);
+  assert.deepEqual(parseShadowRgb("rgb(10 20 30 / 50%)"), [10, 20, 30]);
 });
 
-test("portrait overlays fill the box height and keep their aspect ratio", () => {
-  assert.deepEqual(fitOverlayImage(200, 500, 1000), { width: 100, height: 200 });
-});
-
-test("overlays with unknown natural size fill the box", () => {
-  assert.deepEqual(fitOverlayImage(200, 0, 0), { width: 200, height: 200 });
+test("overlay images keep their aspect ratio inside the square overlay box", () => {
+  assert.deepEqual(fitOverlayImage(1600, 1000), { width: 100, height: 62.5 });
+  assert.deepEqual(fitOverlayImage(500, 1000), { width: 50, height: 100 });
+  assert.deepEqual(fitOverlayImage(0, 0), { width: 100, height: 100 });
 });

--- a/tests/overlay-style.test.ts
+++ b/tests/overlay-style.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildOverlayShadowFilter,
+  buildOverlayTiltTransform,
+  fitOverlayImage,
+  hasOverlayTilt,
+} from "../lib/overlay-style";
+
+test("overlays without tilt render no 3D transform", () => {
+  assert.equal(buildOverlayTiltTransform(undefined), undefined);
+  assert.equal(
+    buildOverlayTiltTransform({ perspective: 600, rotateX: 0, rotateY: 0, rotateZ: 0 }),
+    undefined
+  );
+});
+
+test("tilted overlays render rotateX, rotateY and rotateZ in order", () => {
+  assert.equal(
+    buildOverlayTiltTransform({ perspective: 600, rotateX: 12, rotateY: -20, rotateZ: 3 }),
+    "rotateX(12deg) rotateY(-20deg) rotateZ(3deg)"
+  );
+});
+
+test("hasOverlayTilt is true only when some axis is rotated", () => {
+  assert.equal(hasOverlayTilt(undefined), false);
+  assert.equal(hasOverlayTilt({ perspective: 600, rotateX: 0, rotateY: 0, rotateZ: 0 }), false);
+  assert.equal(hasOverlayTilt({ perspective: 600, rotateX: 0, rotateY: 15, rotateZ: 0 }), true);
+});
+
+test("disabled or missing shadows render no filter", () => {
+  assert.equal(buildOverlayShadowFilter(undefined), undefined);
+  assert.equal(
+    buildOverlayShadowFilter({
+      enabled: false,
+      blur: 15,
+      offsetX: 5,
+      offsetY: 8,
+      spread: 3,
+      color: "rgba(0, 0, 0, 0.6)",
+      opacity: 0.5,
+    }),
+    undefined
+  );
+});
+
+test("enabled shadows render a drop-shadow using blur plus spread and the shadow opacity", () => {
+  assert.equal(
+    buildOverlayShadowFilter({
+      enabled: true,
+      blur: 10,
+      offsetX: 4,
+      offsetY: 6,
+      spread: 2,
+      color: "#102030",
+      opacity: 0.4,
+    }),
+    "drop-shadow(4px 6px 12px rgba(16, 32, 48, 0.4))"
+  );
+});
+
+test("landscape overlays fill the box width and keep their aspect ratio", () => {
+  assert.deepEqual(fitOverlayImage(200, 1600, 1000), { width: 200, height: 125 });
+});
+
+test("portrait overlays fill the box height and keep their aspect ratio", () => {
+  assert.deepEqual(fitOverlayImage(200, 500, 1000), { width: 100, height: 200 });
+});
+
+test("overlays with unknown natural size fill the box", () => {
+  assert.deepEqual(fitOverlayImage(200, 0, 0), { width: 200, height: 200 });
+});


### PR DESCRIPTION
## Summary

Extra images added to the canvas (overlays) could only be positioned, resized, rotated in 2D, faded, blurred and flipped. That makes it hard to compose two or more app screenshots on one canvas: only the main image could be tilted, shadowed or given rounded corners.

This PR is additive and keeps the current model where the first image is the main image and later ones are overlays (as discussed in #111). It does not touch the right-panel zoom slider that #112 addresses.

### Overlays gain three optional fields

- `tilt` (perspective, rotateX, rotateY, rotateZ) with the same ranges as the main image's 3D controls
- `shadow`, reusing the existing `ImageShadow` type
- `radius`, corner radius in pixels

Missing fields mean "off", so existing drafts, presets and stickers render exactly as before.

### Rendering

Overlays are a square box with the image letterboxed inside, so applying a radius or shadow to the box would outline the square rather than the screenshot. The image is now sized to its natural aspect ratio inside the box and the tilt, radius and shadow are applied to it. The outer box is unchanged, so Moveable drag, resize and rotate keep working.

The CSS builders live in `lib/overlay-style.ts` with unit tests in `tests/overlay-style.test.ts`.

### Controls

The Properties panel in the Layers tab (shown when an overlay is selected) gets a Corner radius slider, a 3D Tilt group with a reset button, and a Shadow toggle with blur, offset and opacity sliders.

### Layers panel

The main image is now listed as a read-only row at the bottom of the Layers list, and the Stickers card count includes it. Previously four images on the canvas showed as three layers, which reads as a bug.

### Export fix (second commit)

Exporting while an overlay was selected captured its floating duplicate/delete toolbar in the output. The toolbar is now marked `data-export-exclude`, matching the approach from #109.

## Verification

- `npm test` (44 passing, 8 new)
- `npm run lint` on changed files: no errors (the four existing errors on main are in files this PR does not touch)
- `npm run build` passes
- Manually in the browser: added a main image plus a second screenshot, applied tilt, radius and shadow, dragged the tilted overlay, exported a PNG and confirmed the export matches the canvas with no toolbar. Added two more images and confirmed the Layers panel shows 4.

Refs #111
