### PR TITLE
refactor: of store screenshots workspace, adding new features 

### DIFF
--- a/components/mockups/DeviceShell.tsx
+++ b/components/mockups/DeviceShell.tsx
@@ -18,6 +18,30 @@ interface DeviceShellProps {
   onScreenDoubleClick?: () => void;
   onScreenFile?: (file: File) => void;
   onScreenPointerDown?: PointerEventHandler<HTMLDivElement>;
+  onScreenPointerMove?: PointerEventHandler<HTMLDivElement>;
+  onScreenPointerUp?: PointerEventHandler<HTMLDivElement>;
+  onScreenPointerCancel?: PointerEventHandler<HTMLDivElement>;
+  onScreenKeyDown?: KeyboardEventHandler<HTMLDivElement>;
+}
+
+export function CropGridOverlay({
+  className,
+}: {
+  className?: string;
+}): React.JSX.Element {
+  return (
+    <div
+      data-export-exclude="true"
+      className={cn(
+        "pointer-events-none absolute inset-0 border-2 border-dashed border-background/90 bg-foreground/[0.08]",
+        className,
+      )}
+      style={{
+        "--crop-grid-color": "color-mix(in oklab, var(--background) 45%, transparent)",
+        backgroundImage: "linear-gradient(to right, transparent 33%, var(--crop-grid-color) 33%, var(--crop-grid-color) calc(33% + 1px), transparent calc(33% + 1px), transparent 66%, var(--crop-grid-color) 66%, var(--crop-grid-color) calc(66% + 1px), transparent calc(66% + 1px)), linear-gradient(to bottom, transparent 33%, var(--crop-grid-color) 33%, var(--crop-grid-color) calc(33% + 1px), transparent calc(33% + 1px), transparent 66%, var(--crop-grid-color) 66%, var(--crop-grid-color) calc(66% + 1px), transparent calc(66% + 1px))",
+      } as React.CSSProperties}
+    />
+  );
 }
 
 function Screen({
@@ -32,6 +56,10 @@ function Screen({
   onDoubleClick,
   onFile,
   onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onPointerCancel,
+  onCropKeyDown,
 }: {
   screen: DeviceScreenContent;
   editing: boolean;
@@ -44,6 +72,10 @@ function Screen({
   onDoubleClick?: () => void;
   onFile?: (file: File) => void;
   onPointerDown?: PointerEventHandler<HTMLDivElement>;
+  onPointerMove?: PointerEventHandler<HTMLDivElement>;
+  onPointerUp?: PointerEventHandler<HTMLDivElement>;
+  onPointerCancel?: PointerEventHandler<HTMLDivElement>;
+  onCropKeyDown?: KeyboardEventHandler<HTMLDivElement>;
 }): React.JSX.Element {
   const acceptDroppedImage = ((event) => {
     if (!onFile) return;
@@ -67,6 +99,7 @@ function Screen({
       className={cn(
         "group absolute overflow-hidden bg-muted",
         editing && "ring-2 ring-primary ring-offset-1 ring-offset-foreground/20",
+        editing && "pointer-events-auto cursor-move touch-none",
         onClick && !screen.src && "cursor-pointer",
         className,
       )}
@@ -76,6 +109,10 @@ function Screen({
         onClick();
       }}
       onKeyDown={((event) => {
+        if (editing) {
+          onCropKeyDown?.(event);
+          return;
+        }
         if (!onClick || (event.key !== "Enter" && event.key !== " ")) return;
         event.preventDefault();
         event.stopPropagation();
@@ -94,9 +131,13 @@ function Screen({
       onDrop={acceptDroppedImage}
       onPaste={acceptPastedImage}
       onPointerDown={onPointerDown}
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      aria-label={onClick ? "Upload image to device screen" : undefined}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      role={editing ? "group" : onClick ? "button" : undefined}
+      tabIndex={onClick || editing ? 0 : undefined}
+      aria-label={editing ? "Reposition device screen crop" : onClick ? "Upload image to device screen" : undefined}
+      aria-keyshortcuts={editing ? "ArrowUp ArrowDown ArrowLeft ArrowRight Escape" : undefined}
       data-device-screen-dropzone={onFile ? "" : undefined}
       data-export-clean-device-screen={editing ? "true" : undefined}
       style={{ ...style, touchAction: editing ? "none" : undefined }}
@@ -151,10 +192,7 @@ function Screen({
         </div>
       )}
       {editing ? (
-        <div
-          data-export-exclude="true"
-          className="pointer-events-none absolute inset-0 bg-primary/5"
-        />
+        <CropGridOverlay />
       ) : null}
     </div>
   );
@@ -180,6 +218,10 @@ export function DeviceShell({
   onScreenDoubleClick,
   onScreenFile,
   onScreenPointerDown,
+  onScreenPointerMove,
+  onScreenPointerUp,
+  onScreenPointerCancel,
+  onScreenKeyDown,
 }: DeviceShellProps): React.JSX.Element {
   const shellClass = frameClasses(definition.finish);
   const screenProps = {
@@ -189,6 +231,10 @@ export function DeviceShell({
     onDoubleClick: onScreenDoubleClick,
     onFile: onScreenFile,
     onPointerDown: onScreenPointerDown,
+    onPointerMove: onScreenPointerMove,
+    onPointerUp: onScreenPointerUp,
+    onPointerCancel: onScreenPointerCancel,
+    onCropKeyDown: onScreenKeyDown,
   };
 
   if (definition.asset) {

--- a/components/store-screenshots/StoreExportDialog.tsx
+++ b/components/store-screenshots/StoreExportDialog.tsx
@@ -59,12 +59,12 @@ export function StoreExportDialog({
   project,
   open,
   onOpenChange,
-  onExportComplete,
+  requestId,
 }: {
   project: StoreProject;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onExportComplete?: () => void;
+  requestId: number;
 }): React.JSX.Element {
   const [target, setTarget] = React.useState<RenderTarget>({
     profile: STORE_OUTPUT_PROFILES[0],
@@ -73,8 +73,9 @@ export function StoreExportDialog({
   const [isExporting, setIsExporting] = React.useState(false);
   const [progress, setProgress] = React.useState({ current: 0, total: 0 });
   const renderRef = React.useRef<HTMLDivElement>(null);
+  const handledRequestIdRef = React.useRef(0);
 
-  const exportZip = async (): Promise<void> => {
+  const exportZip = React.useCallback(async (): Promise<void> => {
     if (isExporting) return;
     const profile = STORE_OUTPUT_PROFILES[0];
     const total = project.slides.length;
@@ -113,7 +114,6 @@ export function StoreExportDialog({
         description: `${completed} PNG files packaged for App Store Connect.`,
       });
       onOpenChange(false);
-      onExportComplete?.();
     } catch (cause) {
       toast.error("Store export failed", {
         description: cause instanceof Error ? cause.message : "Please try again.",
@@ -121,7 +121,14 @@ export function StoreExportDialog({
     } finally {
       setIsExporting(false);
     }
-  };
+  }, [isExporting, onOpenChange, project]);
+
+  React.useEffect(() => {
+    if (!open || requestId === 0 || handledRequestIdRef.current === requestId) return;
+    handledRequestIdRef.current = requestId;
+    const frame = window.requestAnimationFrame(() => { void exportZip(); });
+    return () => window.cancelAnimationFrame(frame);
+  }, [exportZip, open, requestId]);
 
   const activeSlide = project.slides[target.slideIndex] ?? project.slides[0];
 

--- a/components/store-screenshots/StoreScreenshotWorkspace.tsx
+++ b/components/store-screenshots/StoreScreenshotWorkspace.tsx
@@ -16,8 +16,10 @@ import {
   FileZipIcon,
   GridIcon,
   NewTwitterIcon,
+  RedoIcon,
   RefreshIcon,
   Settings02Icon,
+  UndoIcon,
 } from "hugeicons-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,8 +43,12 @@ import {
 import { GitHubStarButton } from "@/components/ui/github-star-button";
 import { MobileBanner } from "@/components/editor/MobileBanner";
 import { StoreExportDialog } from "./StoreExportDialog";
-import { StoreGlobalPanel, StoreSlidePanel } from "./StoreSidePanels";
-import { StoreSlideCanvas } from "./StoreSlideCanvas";
+import {
+  StoreGlobalPanel,
+  StoreSlidePanel,
+  type StoreTextFocusRequest,
+} from "./StoreSidePanels";
+import { StoreSlideCanvas, type StoreCropRequest } from "./StoreSlideCanvas";
 import { StoreTemplateGallery } from "./StoreTemplateGallery";
 import { StoreWorkspaceLoading } from "./StoreWorkspaceLoading";
 import {
@@ -57,6 +63,7 @@ import {
   duplicateStoreSlide,
   fileToDataUrl,
   filesToStoreSlides,
+  getStoreDeviceStyleOverride,
   MAX_STORE_PROJECT_IMAGE_BYTES,
   moveStoreSlide,
   removeStoreSlide,
@@ -74,10 +81,16 @@ import {
 } from "@/lib/store-screenshots/storage";
 import type {
   StoreDeviceSlot,
+  StoreImageTransform,
   StoreProject,
   StoreSlide,
 } from "@/lib/store-screenshots/types";
+import {
+  appendStoreHistory,
+  storeHistoryGroupKey,
+} from "@/lib/store-screenshots/history";
 import { cn } from "@/lib/utils";
+import { showStoreUndoToast } from "./store-undo-toast";
 
 const PAGE_SIZE = 4;
 
@@ -113,12 +126,20 @@ function StoreStarterChoice({
 function StoreHeader({
   onExport,
   onReset,
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
   resetButtonRef,
   disabled = false,
   showActions = true,
 }: {
   onExport: () => void;
   onReset: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
   resetButtonRef?: React.Ref<HTMLButtonElement>;
   disabled?: boolean;
   showActions?: boolean;
@@ -136,18 +157,45 @@ function StoreHeader({
 
       {showActions ? (
         <>
-          <Button
-            ref={resetButtonRef}
-            type="button"
-            onClick={onReset}
-            disabled={disabled}
-            variant="outline"
-            size="sm"
-            className="absolute left-1/2 h-8 -translate-x-1/2 px-2.5 text-xs text-muted-foreground hover:text-foreground"
-          >
-            <RefreshIcon size={14} />
-            Start over
-          </Button>
+          <div className="absolute left-1/2 flex -translate-x-1/2 items-center gap-1">
+            <Button
+              type="button"
+              onClick={onUndo}
+              disabled={disabled || !canUndo}
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Undo last edit"
+              title="Undo (⌘Z)"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <UndoIcon size={14} />
+            </Button>
+            <Button
+              type="button"
+              onClick={onRedo}
+              disabled={disabled || !canRedo}
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Redo last edit"
+              title="Redo (⇧⌘Z)"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <RedoIcon size={14} />
+            </Button>
+            <div className="mx-1 h-4 w-px bg-foreground/10" />
+            <Button
+              ref={resetButtonRef}
+              type="button"
+              onClick={onReset}
+              disabled={disabled}
+              variant="outline"
+              size="sm"
+              className="h-8 px-2.5 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <RefreshIcon size={14} />
+              Start over
+            </Button>
+          </div>
           <div className="flex items-center gap-1.5">
             <Button
               size="sm"
@@ -198,32 +246,66 @@ function SlideCard({
   const profile = getStoreProfile("app-store");
 
   return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onOpen}
-      onKeyDown={(event) => {
-        if (!event.shiftKey || (event.key !== "ArrowLeft" && event.key !== "ArrowRight")) return;
-        event.preventDefault();
-        onMove(event.key === "ArrowLeft" ? -1 : 1);
-      }}
-      aria-label={`Edit screenshot ${index + 1} of ${project.slides.length}`}
-      aria-describedby="store-reorder-instructions"
-      aria-keyshortcuts="Shift+ArrowLeft Shift+ArrowRight"
-      className={cn(
-        "group relative block w-full overflow-hidden border border-foreground/10 bg-card text-left shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30",
-        disabled
-          ? "cursor-default rounded-xl"
-          : "rounded-md transition-[transform,border-color,box-shadow] hover:-translate-y-0.5 hover:border-foreground/25",
-      )}
-    >
-      <StoreSlideCanvas project={project} slide={slide} slideIndex={index} profile={profile} className="w-full" />
+    <div className="group relative w-full">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onOpen}
+        onKeyDown={(event) => {
+          if (!event.shiftKey || (event.key !== "ArrowLeft" && event.key !== "ArrowRight")) return;
+          event.preventDefault();
+          onMove(event.key === "ArrowLeft" ? -1 : 1);
+        }}
+        aria-label={`Edit screenshot ${index + 1} of ${project.slides.length}`}
+        aria-describedby="store-reorder-instructions"
+        aria-keyshortcuts="Shift+ArrowLeft Shift+ArrowRight"
+        className={cn(
+          "relative block w-full overflow-hidden border border-foreground/10 bg-card text-left shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30",
+          disabled
+            ? "cursor-default rounded-xl"
+            : "rounded-md transition-[transform,border-color,box-shadow] hover:-translate-y-0.5 hover:border-foreground/25",
+        )}
+      >
+        <StoreSlideCanvas project={project} slide={slide} slideIndex={index} profile={profile} className="w-full" />
+        {!disabled ? (
+          <span className="absolute inset-x-0 bottom-0 translate-y-full bg-foreground/75 px-2 py-2 text-center text-[10px] font-medium text-background backdrop-blur-sm transition-transform group-hover:translate-y-0 group-focus-within:translate-y-0">
+            Edit screenshot
+          </span>
+        ) : null}
+      </button>
       {!disabled ? (
-        <span className="absolute inset-x-0 bottom-0 translate-y-full bg-foreground/75 px-2 py-2 text-center text-[10px] font-medium text-background backdrop-blur-sm transition-transform group-hover:translate-y-0">
-          Edit screenshot
-        </span>
+        <div className="absolute right-2 top-2 z-20 flex gap-1 rounded-md border border-foreground/10 bg-background/90 p-1 shadow-sm backdrop-blur-sm">
+          <button
+            type="button"
+            disabled={index === 0}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMove(-1);
+            }}
+            aria-label={`Move screenshot ${index + 1} left`}
+            title="Move left"
+            className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-foreground/[0.07] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 disabled:pointer-events-none disabled:opacity-30"
+          >
+            <ArrowLeft02Icon size={13} />
+          </button>
+          <button
+            type="button"
+            disabled={index === project.slides.length - 1}
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              onMove(1);
+            }}
+            aria-label={`Move screenshot ${index + 1} right`}
+            title="Move right"
+            className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-foreground/[0.07] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30 disabled:pointer-events-none disabled:opacity-30"
+          >
+            <ArrowRight02Icon size={13} />
+          </button>
+        </div>
       ) : null}
-    </button>
+    </div>
   );
 }
 
@@ -456,6 +538,11 @@ function StoreFocus({
   onDuplicate,
   onDelete,
   onSlideChange,
+  onScreenFile,
+  onScreenDelete,
+  onScreenImageChange,
+  cropRequest,
+  onTextEditRequest,
   onDeviceSelect,
   selectedDeviceSlot,
   canAdd,
@@ -472,6 +559,11 @@ function StoreFocus({
   onDuplicate: () => void;
   onDelete: () => void;
   onSlideChange: (slide: StoreSlide) => void;
+  onScreenFile: (sourceSlideId: string, file: File) => void;
+  onScreenDelete: (sourceSlideId: string) => void;
+  onScreenImageChange: (sourceSlideId: string, image: StoreImageTransform) => void;
+  cropRequest: StoreCropRequest | null;
+  onTextEditRequest: (field: "heading" | "subheading") => void;
   onDeviceSelect: (slot: StoreDeviceSlot | null) => void;
   selectedDeviceSlot: StoreDeviceSlot | null;
   canAdd: boolean;
@@ -505,6 +597,11 @@ function StoreFocus({
             style={{ width: "clamp(220px, calc(46.025vh - 92px), 500px)" }}
             interactive
             onSlideChange={onSlideChange}
+            onScreenFile={onScreenFile}
+            onScreenDelete={onScreenDelete}
+            onScreenImageChange={onScreenImageChange}
+            cropRequest={cropRequest}
+            onTextEditRequest={onTextEditRequest}
             onDeviceSelect={onDeviceSelect}
             selectedDeviceSlot={selectedDeviceSlot}
           />
@@ -646,6 +743,7 @@ export function StoreScreenshotWorkspace({
   const [view, setView] = React.useState<"overview" | "focus">("focus");
   const [page, setPage] = React.useState(0);
   const [exportOpen, setExportOpen] = React.useState(false);
+  const [exportRequestId, setExportRequestId] = React.useState(0);
   const [resetDialogOpen, setResetDialogOpen] = React.useState(false);
   const [showStarterChoice, setShowStarterChoice] = React.useState(false);
   const [templateGalleryOpen, setTemplateGalleryOpen] = React.useState(false);
@@ -653,6 +751,9 @@ export function StoreScreenshotWorkspace({
   const [controlsOpen, setControlsOpen] = React.useState(false);
   const [responsivePanel, setResponsivePanel] = React.useState<"design" | "content">("content");
   const [reorderAnnouncement, setReorderAnnouncement] = React.useState("");
+  const [textFocusRequest, setTextFocusRequest] = React.useState<StoreTextFocusRequest | null>(null);
+  const [cropRequest, setCropRequest] = React.useState<StoreCropRequest | null>(null);
+  const [historyAvailability, setHistoryAvailability] = React.useState({ canUndo: false, canRedo: false });
   const addInputRef = React.useRef<HTMLInputElement>(null);
   const resetButtonRef = React.useRef<HTMLButtonElement>(null);
   const saveErrorShownRef = React.useRef(false);
@@ -664,29 +765,76 @@ export function StoreScreenshotWorkspace({
   const projectGenerationRef = React.useRef(0);
   const persistenceGenerationRef = React.useRef(0);
   const replacementRequestIdsRef = React.useRef<Map<string, number>>(new Map());
+  const undoStackRef = React.useRef<StoreProject[]>([]);
+  const redoStackRef = React.useRef<StoreProject[]>([]);
+  const historyGroupKeyRef = React.useRef<string | null>(null);
+  const historyTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const setCurrentProject = React.useCallback((next: StoreProject | null): void => {
+  const syncHistoryAvailability = React.useCallback((): void => {
+    setHistoryAvailability({
+      canUndo: undoStackRef.current.length > 0,
+      canRedo: redoStackRef.current.length > 0,
+    });
+  }, []);
+
+  const closeHistoryGroup = React.useCallback((): void => {
+    historyGroupKeyRef.current = null;
+    if (historyTimerRef.current) {
+      clearTimeout(historyTimerRef.current);
+      historyTimerRef.current = null;
+    }
+  }, []);
+
+  const clearHistory = React.useCallback((): void => {
+    closeHistoryGroup();
+    undoStackRef.current = [];
+    redoStackRef.current = [];
+    syncHistoryAvailability();
+  }, [closeHistoryGroup, syncHistoryAvailability]);
+
+  const setCurrentProject = React.useCallback((
+    next: StoreProject | null,
+    historyMode: "record" | "skip" = "record",
+  ): void => {
+    const previous = projectRef.current;
+    if (historyMode === "record" && previous && next && previous !== next) {
+      const groupKey = storeHistoryGroupKey(previous, next);
+      if (!groupKey || historyGroupKeyRef.current !== groupKey) {
+        undoStackRef.current = appendStoreHistory(undoStackRef.current, previous, next);
+      }
+      redoStackRef.current = [];
+      closeHistoryGroup();
+      if (groupKey) {
+        historyGroupKeyRef.current = groupKey;
+        historyTimerRef.current = setTimeout(() => {
+          historyGroupKeyRef.current = null;
+          historyTimerRef.current = null;
+        }, 500);
+      }
+      syncHistoryAvailability();
+    }
     projectRef.current = next;
     setProject(next);
-  }, []);
+  }, [closeHistoryGroup, syncHistoryAvailability]);
 
   React.useEffect(() => {
     let active = true;
     void loadStoreProject().then((savedProject) => {
       if (!active) return;
       if (savedProject) {
-        setCurrentProject(savedProject);
+        setCurrentProject(savedProject, "skip");
         setShowStarterChoice(false);
         setView("focus");
       } else {
-        setCurrentProject(createStarterStoreProject());
+        setCurrentProject(createStarterStoreProject(), "skip");
         setShowStarterChoice(true);
         setView("overview");
       }
+      clearHistory();
       setLoaded(true);
     });
     return () => { active = false; };
-  }, [setCurrentProject]);
+  }, [clearHistory, setCurrentProject]);
 
   const queueProjectSave = React.useCallback((projectToSave: StoreProject): void => {
     const persistenceGeneration = persistenceGenerationRef.current;
@@ -696,7 +844,9 @@ export function StoreScreenshotWorkspace({
       .then(() => saveStoreProject(projectToSave));
     saveQueueRef.current = save;
     void save
-      .then(() => { saveErrorShownRef.current = false; })
+      .then(() => {
+        saveErrorShownRef.current = false;
+      })
       .catch(() => {
         if (persistenceGeneration !== persistenceGenerationRef.current) return;
         const pending = pendingProjectRef.current;
@@ -743,6 +893,10 @@ export function StoreScreenshotWorkspace({
     };
   }, [flushPendingSave, loaded, project, showStarterChoice]);
 
+  React.useEffect(() => () => {
+    if (historyTimerRef.current) clearTimeout(historyTimerRef.current);
+  }, []);
+
   React.useEffect(() => {
     const handleVisibilityChange = (): void => {
       if (document.visibilityState === "hidden") flushPendingSave();
@@ -779,6 +933,50 @@ export function StoreScreenshotWorkspace({
     setCurrentProject({ ...next, updatedAt: Date.now() });
   }, [setCurrentProject]);
 
+  const undo = React.useCallback((): void => {
+    const current = projectRef.current;
+    const previous = undoStackRef.current.at(-1);
+    if (!current || !previous) return;
+    closeHistoryGroup();
+    undoStackRef.current = undoStackRef.current.slice(0, -1);
+    const restored = { ...previous, updatedAt: Date.now() };
+    redoStackRef.current = appendStoreHistory(redoStackRef.current, current, restored);
+    setCurrentProject(restored, "skip");
+    setShowStarterChoice(false);
+    syncHistoryAvailability();
+  }, [closeHistoryGroup, setCurrentProject, syncHistoryAvailability]);
+
+  const redo = React.useCallback((): void => {
+    const current = projectRef.current;
+    const next = redoStackRef.current.at(-1);
+    if (!current || !next) return;
+    closeHistoryGroup();
+    redoStackRef.current = redoStackRef.current.slice(0, -1);
+    const restored = { ...next, updatedAt: Date.now() };
+    undoStackRef.current = appendStoreHistory(undoStackRef.current, current, restored);
+    setCurrentProject(restored, "skip");
+    setShowStarterChoice(false);
+    syncHistoryAvailability();
+  }, [closeHistoryGroup, setCurrentProject, syncHistoryAvailability]);
+
+  React.useEffect(() => {
+    const handleHistoryShortcut = (event: KeyboardEvent): void => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "z") return;
+      const target = event.target;
+      if (target instanceof HTMLElement && (
+        target.isContentEditable
+        || target instanceof HTMLInputElement
+        || target instanceof HTMLTextAreaElement
+        || target instanceof HTMLSelectElement
+      )) return;
+      event.preventDefault();
+      if (event.shiftKey) redo();
+      else undo();
+    };
+    window.addEventListener("keydown", handleHistoryShortcut);
+    return () => window.removeEventListener("keydown", handleHistoryShortcut);
+  }, [redo, undo]);
+
   if (!loaded) {
     return <StoreWorkspaceLoading variant={initialHasSavedProject ? "editor" : "templates"} />;
   }
@@ -789,9 +987,31 @@ export function StoreScreenshotWorkspace({
 
   const selectedSlide = project.slides.find((slide) => slide.id === project.selectedSlideId)
     ?? project.slides[0];
+  const selectedSlideIndex = project.slides.findIndex((slide) => slide.id === selectedSlide.id);
+  const selectedLayoutId = resolveStoreLayout(
+    project.templateId,
+    selectedSlideIndex,
+    selectedSlide.layoutOverride,
+  );
+  const selectedDeviceSlot = selectedLayoutId === "duo" && activeDeviceSlot === "secondary"
+    ? "secondary"
+    : "primary";
+  const fallbackRightSlide = project.slides[(selectedSlideIndex + 1) % project.slides.length]
+    ?? selectedSlide;
+  const selectedScreenSlide = selectedLayoutId === "duo"
+    ? selectedDeviceSlot === "secondary"
+      ? project.slides.find((slide) => slide.id === selectedSlide.duoRightSlideId) ?? fallbackRightSlide
+      : project.slides.find((slide) => slide.id === selectedSlide.duoLeftSlideId) ?? selectedSlide
+    : selectedSlide;
+  const selectedScreenLabel = selectedLayoutId === "duo"
+    ? selectedDeviceSlot === "secondary" ? "Right" : "Left"
+    : "Screenshot";
+  const selectedScreenUsesDeviceFrame = (
+    getStoreDeviceStyleOverride(selectedSlide, selectedDeviceSlot) ?? project.theme.deviceStyle
+  ) === "iphone";
 
   const selectSlide = (id: string, focus = true): void => {
-    commitProject({ ...project, selectedSlideId: id });
+    setCurrentProject({ ...project, selectedSlideId: id, updatedAt: Date.now() }, "skip");
     setActiveDeviceSlot("primary");
     if (focus) setView("focus");
   };
@@ -911,7 +1131,8 @@ export function StoreScreenshotWorkspace({
 
   const applyAppTemplate = (templateProject: StoreProject): void => {
     projectGenerationRef.current += 1;
-    setCurrentProject(templateProject);
+    clearHistory();
+    setCurrentProject(templateProject, "skip");
     queueProjectSave(templateProject);
     setActiveDeviceSlot("primary");
     setTemplateGalleryOpen(false);
@@ -931,7 +1152,8 @@ export function StoreScreenshotWorkspace({
   const startFromScratch = (): void => {
     projectGenerationRef.current += 1;
     const scratchProject = createScratchStoreProject();
-    setCurrentProject(scratchProject);
+    clearHistory();
+    setCurrentProject(scratchProject, "skip");
     setShowStarterChoice(false);
     setActiveDeviceSlot("primary");
     setView("focus");
@@ -973,14 +1195,15 @@ export function StoreScreenshotWorkspace({
     }
   };
 
-  const removeProject = (): Promise<void> => {
+  const removeProject = (clearEditorHistory = true): Promise<void> => {
     persistenceGenerationRef.current += 1;
+    if (clearEditorHistory) clearHistory();
     pendingProjectRef.current = null;
     if (saveTimerRef.current) {
       clearTimeout(saveTimerRef.current);
       saveTimerRef.current = null;
     }
-    setCurrentProject(createStarterStoreProject());
+    setCurrentProject(createStarterStoreProject(), "skip");
     setShowStarterChoice(true);
     setActiveDeviceSlot("primary");
     setView("overview");
@@ -999,13 +1222,70 @@ export function StoreScreenshotWorkspace({
   };
 
   const deleteSelectedSlide = (): void => {
+    const deletedSlide = selectedSlide;
+    const deletedIndex = project.slides.findIndex((slide) => slide.id === deletedSlide.id);
+    const deletionGeneration = projectGenerationRef.current;
     const nextProject = removeStoreSlide(project, selectedSlide.id);
+    let clearedProject: StoreProject | null = null;
     if (!nextProject) {
-      void removeProject();
-      return;
+      void removeProject(false);
+      clearedProject = projectRef.current;
+    } else {
+      commitProject(nextProject);
+      setActiveDeviceSlot("primary");
     }
-    commitProject(nextProject);
-    setActiveDeviceSlot("primary");
+
+    showStoreUndoToast("Screenshot deleted", () => {
+      if (projectGenerationRef.current !== deletionGeneration) {
+        toast.error("Could not restore this screenshot", {
+          description: "The screenshot set has been replaced.",
+        });
+        return;
+      }
+      const current = projectRef.current;
+      if (!current || current.slides.some((slide) => slide.id === deletedSlide.id)) return;
+
+      const restoringClearedProject = clearedProject !== null && current === clearedProject;
+      if (restoringClearedProject) {
+        const restoredProject = { ...project, updatedAt: Date.now() };
+        setCurrentProject(restoredProject, "skip");
+        setShowStarterChoice(false);
+        setView("focus");
+        setActiveDeviceSlot("primary");
+        return;
+      }
+
+      if (current.slides.length >= MAX_STORE_SLIDES) {
+        toast.error("Could not restore this screenshot", {
+          description: `A project can contain up to ${MAX_STORE_SLIDES} screenshots.`,
+        });
+        return;
+      }
+
+      try {
+        assertStoreImageBudget(
+          storeSlidesImageBytes(current.slides),
+          storeSlideImageBytes(deletedSlide),
+        );
+      } catch (cause) {
+        toast.error("Could not restore this screenshot", {
+          description: cause instanceof Error ? cause.message : "Remove another image and try again.",
+        });
+        return;
+      }
+
+      const slides = [...current.slides];
+      slides.splice(Math.min(deletedIndex, slides.length), 0, deletedSlide);
+      setCurrentProject({
+        ...current,
+        slides,
+        selectedSlideId: deletedSlide.id,
+        updatedAt: Date.now(),
+      }, "skip");
+      setShowStarterChoice(false);
+      setView("focus");
+      setActiveDeviceSlot("primary");
+    });
   };
 
   const reset = (): void => {
@@ -1020,8 +1300,8 @@ export function StoreScreenshotWorkspace({
     }
   };
 
-  const replaceSelectedImage = (file: File): void => {
-    const slideId = selectedSlide.id;
+  const replaceImage = (file: File, slideId: string): void => {
+    const sourceSlide = project.slides.find((candidate) => candidate.id === slideId) ?? selectedSlide;
     const projectGeneration = projectGenerationRef.current;
     const requestId = (replacementRequestIdsRef.current.get(slideId) ?? 0) + 1;
     replacementRequestIdsRef.current.set(slideId, requestId);
@@ -1030,7 +1310,7 @@ export function StoreScreenshotWorkspace({
         assertStoreImageBudget(
           storeSlidesImageBytes(project.slides),
           file.size,
-          storeDataUrlBytes(selectedSlide.src),
+          storeDataUrlBytes(sourceSlide.src),
         );
         const src = await fileToDataUrl(file);
         if (projectGenerationRef.current !== projectGeneration) return;
@@ -1061,6 +1341,63 @@ export function StoreScreenshotWorkspace({
     })();
   };
 
+  const replaceScreenImage = (sourceSlideId: string, file: File): void => {
+    replaceImage(file, sourceSlideId);
+  };
+
+  const deleteScreenImage = (sourceSlideId: string): void => {
+    const sourceSlide = projectRef.current?.slides.find((slide) => slide.id === sourceSlideId);
+    if (!sourceSlide || !sourceSlide.src) return;
+    const deletedImage = {
+      src: sourceSlide.src,
+      name: sourceSlide.name,
+      image: { ...sourceSlide.image },
+    };
+
+    patchSlide(sourceSlideId, {
+      src: "",
+      name: "Empty screen",
+      image: { mode: "fill", scale: 1, offsetX: 0, offsetY: 0 },
+    });
+
+    showStoreUndoToast("Screen image deleted", () => {
+      const current = projectRef.current;
+      const currentSlide = current?.slides.find((slide) => slide.id === sourceSlideId);
+      if (!current || !currentSlide) return;
+      setCurrentProject({
+        ...current,
+        slides: current.slides.map((slide) => slide.id === sourceSlideId
+          ? { ...slide, ...deletedImage }
+          : slide),
+        updatedAt: Date.now(),
+      }, "skip");
+    });
+  };
+
+  const updateScreenImage = (sourceSlideId: string, image: StoreImageTransform): void => {
+    patchSlide(sourceSlideId, { image });
+  };
+
+  const requestScreenCrop = (sourceSlideId: string, original: StoreImageTransform): void => {
+    setControlsOpen(false);
+    setCropRequest((current) => ({
+      id: (current?.id ?? 0) + 1,
+      sourceSlideId,
+      original,
+    }));
+  };
+
+  const focusCopyField = (field: "heading" | "subheading"): void => {
+    setResponsivePanel("content");
+    if (window.innerWidth < 1280) setControlsOpen(true);
+    setTextFocusRequest((current) => ({ field, id: (current?.id ?? 0) + 1 }));
+  };
+
+  const beginExport = (): void => {
+    setExportRequestId((current) => current + 1);
+    setExportOpen(true);
+  };
+
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-background">
       <p id="store-reorder-instructions" className="sr-only">
@@ -1071,8 +1408,12 @@ export function StoreScreenshotWorkspace({
       </p>
       <MobileBanner />
       <StoreHeader
-        onExport={() => setExportOpen(true)}
+        onExport={beginExport}
         onReset={() => setResetDialogOpen(true)}
+        onUndo={undo}
+        onRedo={redo}
+        canUndo={historyAvailability.canUndo}
+        canRedo={historyAvailability.canRedo}
         resetButtonRef={resetButtonRef}
         showActions={!showStarterChoice && !templateGalleryOpen}
       />
@@ -1122,6 +1463,11 @@ export function StoreScreenshotWorkspace({
                 onDuplicate={duplicateSelectedSlide}
                 onDelete={deleteSelectedSlide}
                 onSlideChange={updateSlide}
+                onScreenFile={replaceScreenImage}
+                onScreenDelete={deleteScreenImage}
+                onScreenImageChange={updateScreenImage}
+                cropRequest={cropRequest}
+                onTextEditRequest={focusCopyField}
                 onDeviceSelect={setActiveDeviceSlot}
                 selectedDeviceSlot={activeDeviceSlot}
                 canAdd={project.slides.length < MAX_STORE_SLIDES}
@@ -1134,12 +1480,11 @@ export function StoreScreenshotWorkspace({
         {!showStarterChoice && !templateGalleryOpen ? (
           <StoreSlidePanel
             slide={selectedSlide}
+            screenSlide={selectedScreenSlide}
+            screenLabel={selectedScreenLabel}
+            usesDeviceFrame={selectedScreenUsesDeviceFrame}
             slides={project.slides}
-            isDuo={resolveStoreLayout(
-              project.templateId,
-              project.slides.findIndex((slide) => slide.id === selectedSlide.id),
-              selectedSlide.layoutOverride,
-            ) === "duo"}
+            isDuo={selectedLayoutId === "duo"}
             theme={project.theme}
             onChange={patchSlide}
             onThemeChange={(updates) => commitProject({
@@ -1147,7 +1492,9 @@ export function StoreScreenshotWorkspace({
               theme: { ...project.theme, ...updates },
             })}
             onApplyTextColorToAll={applyTextColorToAll}
-            onReplace={replaceSelectedImage}
+            onReplace={(slideId, file) => replaceImage(file, slideId)}
+            onCropRequest={requestScreenCrop}
+            textFocusRequest={textFocusRequest}
           />
         ) : null}
       </div>
@@ -1169,10 +1516,7 @@ export function StoreScreenshotWorkspace({
         project={project}
         open={exportOpen}
         onOpenChange={setExportOpen}
-        onExportComplete={() => {
-          projectGenerationRef.current += 1;
-          void removeProject();
-        }}
+        requestId={exportRequestId}
       />
 
       <AlertDialog open={resetDialogOpen} onOpenChange={handleResetDialogOpenChange}>
@@ -1241,12 +1585,11 @@ export function StoreScreenshotWorkspace({
             ) : (
               <StoreSlidePanel
                 slide={selectedSlide}
+                screenSlide={selectedScreenSlide}
+                screenLabel={selectedScreenLabel}
+                usesDeviceFrame={selectedScreenUsesDeviceFrame}
                 slides={project.slides}
-                isDuo={resolveStoreLayout(
-                  project.templateId,
-                  project.slides.findIndex((slide) => slide.id === selectedSlide.id),
-                  selectedSlide.layoutOverride,
-                ) === "duo"}
+                isDuo={selectedLayoutId === "duo"}
                 theme={project.theme}
                 onChange={patchSlide}
                 onThemeChange={(updates) => commitProject({
@@ -1254,7 +1597,9 @@ export function StoreScreenshotWorkspace({
                   theme: { ...project.theme, ...updates },
                 })}
                 onApplyTextColorToAll={applyTextColorToAll}
-                onReplace={replaceSelectedImage}
+                onReplace={(slideId, file) => replaceImage(file, slideId)}
+                onCropRequest={requestScreenCrop}
+                textFocusRequest={textFocusRequest}
                 embedded
               />
             )}
@@ -1270,7 +1615,7 @@ export function StoreScreenshotWorkspace({
           {view === "overview" ? <ArrowRight02Icon size={14} /> : <GridIcon size={14} />}
           {view === "overview" ? "Edit" : "Overview"}
         </Button>
-        <Button className="md:hidden" size="sm" onClick={() => setExportOpen(true)}><FileZipIcon size={14} /> Export</Button>
+        <Button className="md:hidden" size="sm" onClick={beginExport}><FileZipIcon size={14} /> Export</Button>
       </div>
     </div>
   );

--- a/components/store-screenshots/StoreSidePanels.tsx
+++ b/components/store-screenshots/StoreSidePanels.tsx
@@ -46,14 +46,20 @@ import type {
   StoreDeviceSlot,
   StoreDeviceStyle,
   StoreExtraText,
+  StoreImageTransform,
   StoreProject,
   StoreSlide,
 } from "@/lib/store-screenshots/types";
 import { cn } from "@/lib/utils";
+import { showStoreUndoToast } from "./store-undo-toast";
 
-type GlobalTab = "templates" | "theme";
+type GlobalTab = "layout" | "theme";
 type SlideTab = "content" | "advanced";
 type TextColorScope = "slide" | "all";
+export type StoreTextFocusRequest = {
+  field: "heading" | "subheading";
+  id: number;
+};
 
 function Section({
   title,
@@ -212,7 +218,7 @@ export function StoreGlobalPanel({
   deviceSlot?: StoreDeviceSlot | null;
   embedded?: boolean;
 }): React.JSX.Element {
-  const [tab, setTab] = React.useState<GlobalTab>("templates");
+  const [tab, setTab] = React.useState<GlobalTab>("layout");
   const backgroundInputRef = React.useRef<HTMLInputElement>(null);
   const backgroundRequestIdsRef = React.useRef<Map<string, number>>(new Map());
   const projectRef = React.useRef(project);
@@ -298,7 +304,7 @@ export function StoreGlobalPanel({
           value={tab}
           onChange={(value) => setTab(value as GlobalTab)}
           options={[
-            { id: "templates", icon: <Layers01Icon size={14} />, ariaLabel: "Templates" },
+            { id: "layout", icon: <Layers01Icon size={14} />, ariaLabel: "Layout" },
             { id: "theme", icon: <PaintBoardIcon size={14} />, ariaLabel: "Theme" },
           ]}
         />
@@ -312,7 +318,7 @@ export function StoreGlobalPanel({
         </div>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4 scrollbar-hide">
-        {tab === "templates" ? (
+        {tab === "layout" ? (
           <div className="space-y-4">
             <Section title="Slide layout">
               <div className="grid grid-cols-2 gap-1.5">
@@ -343,9 +349,9 @@ export function StoreGlobalPanel({
             </Section>
             {selectedSlide && selectedLayoutId !== "no-mockup" ? (
               <>
-                <Section title="Slide treatment">
+                <Section title="Presentation">
                   <div className="space-y-2">
-                    <span className="text-xs text-muted-foreground">Device frame</span>
+                    <span className="text-xs text-muted-foreground">Show as</span>
                     <SegmentedControl
                       size="sm"
                       value={selectedDeviceStyle}
@@ -356,7 +362,7 @@ export function StoreGlobalPanel({
                       ))}
                       options={[
                         { id: "iphone", label: "iPhone" },
-                        { id: "screen-only", label: "Screen" },
+                        { id: "screen-only", label: "Image" },
                       ]}
                     />
                   </div>
@@ -498,13 +504,19 @@ export function StoreGlobalPanel({
                         aria-label="Remove custom slide background"
                         title="Remove custom background"
                         onClick={() => {
+                          const deletedBackground = selectedSlide.backgroundImageOverride;
                           backgroundRequestIdsRef.current.set(
                             selectedSlide.id,
                             (backgroundRequestIdsRef.current.get(selectedSlide.id) ?? 0) + 1,
                           );
                           updateSelectedSlide({ backgroundImageOverride: null });
+                          showStoreUndoToast("Background removed", () => {
+                            onSlideChange(selectedSlide.id, {
+                              backgroundImageOverride: deletedBackground,
+                            });
+                          });
                         }}
-                        className="flex size-7 shrink-0 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
+                        className="flex size-8 shrink-0 items-center justify-center rounded-md text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
                       >
                         <Cancel01Icon size={13} />
                       </button>
@@ -564,6 +576,9 @@ export function StoreGlobalPanel({
 
 export function StoreSlidePanel({
   slide,
+  screenSlide,
+  screenLabel,
+  usesDeviceFrame,
   slides,
   isDuo,
   theme,
@@ -571,16 +586,23 @@ export function StoreSlidePanel({
   onThemeChange,
   onApplyTextColorToAll,
   onReplace,
+  onCropRequest,
+  textFocusRequest,
   embedded = false,
 }: {
   slide: StoreSlide | null;
+  screenSlide: StoreSlide | null;
+  screenLabel: string;
+  usesDeviceFrame: boolean;
   slides: StoreSlide[];
   isDuo: boolean;
   theme: StoreProject["theme"];
   onChange: (slideId: string, updates: Partial<StoreSlide>) => void;
   onThemeChange: (updates: Partial<StoreProject["theme"]>) => void;
   onApplyTextColorToAll: (key: "headlineColor" | "subheadColor", value: string) => void;
-  onReplace: (file: File) => void;
+  onReplace: (slideId: string, file: File) => void;
+  onCropRequest: (sourceSlideId: string, original: StoreImageTransform) => void;
+  textFocusRequest?: StoreTextFocusRequest | null;
   embedded?: boolean;
 }): React.JSX.Element {
   const [tab, setTab] = React.useState<SlideTab>("content");
@@ -588,8 +610,30 @@ export function StoreSlidePanel({
   const overlayInputRef = React.useRef<HTMLInputElement>(null);
   const overlayRequestIdsRef = React.useRef<Map<string, number>>(new Map());
   const replaceInputRef = React.useRef<HTMLInputElement>(null);
+  const headingInputRef = React.useRef<HTMLTextAreaElement>(null);
+  const subheadingInputRef = React.useRef<HTMLTextAreaElement>(null);
+  const slideRef = React.useRef(slide);
 
-  if (!slide) {
+  React.useEffect(() => {
+    slideRef.current = slide;
+  }, [slide]);
+
+  React.useEffect(() => {
+    if (!textFocusRequest) return;
+    setTab("content");
+    const frame = window.requestAnimationFrame(() => {
+      const input = textFocusRequest.field === "heading"
+        ? headingInputRef.current
+        : subheadingInputRef.current;
+      if (!input || input.offsetParent === null) return;
+      input.focus({ preventScroll: true });
+      input.setSelectionRange(input.value.length, input.value.length);
+      input.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [textFocusRequest]);
+
+  if (!slide || !screenSlide) {
     return (
       <aside
         className={cn(
@@ -637,12 +681,12 @@ export function StoreSlidePanel({
   const rightSlideId = slides.some((candidate) => candidate.id === slide.duoRightSlideId)
     ? slide.duoRightSlideId!
     : fallbackRightSlide.id;
-  const usesDeviceFrame = (slide.deviceStyleOverride ?? theme.deviceStyle) === "iphone";
-  const imageMode = slide.image.mode ?? "fill";
+  const imageMode = screenSlide.image.mode ?? "fill";
   const imageFramingChanged = imageMode !== "fill"
-    || slide.image.scale !== 1
-    || slide.image.offsetX !== 0
-    || slide.image.offsetY !== 0;
+    || screenSlide.image.scale !== 1
+    || screenSlide.image.offsetX !== 0
+    || screenSlide.image.offsetY !== 0;
+  const screenImageLabel = isDuo ? `${screenLabel.toLowerCase()} image` : "image";
 
   return (
     <aside
@@ -674,14 +718,21 @@ export function StoreSlidePanel({
                       type="button"
                       aria-label="Delete heading"
                       title="Delete heading"
-                      onClick={() => update({ headline: "" })}
-                      className="flex size-6 items-center justify-center rounded text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
+                      onClick={() => {
+                        const deletedHeading = slide.headline;
+                        update({ headline: "" });
+                        showStoreUndoToast("Heading deleted", () => {
+                          onChange(slide.id, { headline: deletedHeading });
+                        });
+                      }}
+                      className="flex size-8 items-center justify-center rounded text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
                     >
                       <Cancel01Icon size={12} />
                     </button>
                   ) : null}
                 </div>
                 <textarea
+                  ref={headingInputRef}
                   aria-label="Heading"
                   rows={2}
                   value={slide.headline}
@@ -699,14 +750,21 @@ export function StoreSlidePanel({
                       type="button"
                       aria-label="Delete subheading"
                       title="Delete subheading"
-                      onClick={() => update({ subhead: "" })}
-                      className="flex size-6 items-center justify-center rounded text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
+                      onClick={() => {
+                        const deletedSubheading = slide.subhead;
+                        update({ subhead: "" });
+                        showStoreUndoToast("Subheading deleted", () => {
+                          onChange(slide.id, { subhead: deletedSubheading });
+                        });
+                      }}
+                      className="flex size-8 items-center justify-center rounded text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
                     >
                       <Cancel01Icon size={12} />
                     </button>
                   ) : null}
                 </div>
                 <textarea
+                  ref={subheadingInputRef}
                   aria-label="Subheading"
                   rows={2}
                   value={slide.subhead}
@@ -732,8 +790,19 @@ export function StoreSlidePanel({
                         type="button"
                         aria-label={`Remove text block ${index + 1}`}
                         title="Remove text"
-                        onClick={() => update({ extraTexts: extraTexts.filter((item) => item.id !== text.id) })}
-                        className="flex size-6 items-center justify-center rounded text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
+                        onClick={() => {
+                          update({ extraTexts: extraTexts.filter((item) => item.id !== text.id) });
+                          showStoreUndoToast("Text block removed", () => {
+                            const currentSlide = slideRef.current;
+                            if (!currentSlide || currentSlide.id !== slide.id) return;
+                            const currentTexts = currentSlide.extraTexts ?? [];
+                            if (currentTexts.some((item) => item.id === text.id)) return;
+                            const restoredTexts = [...currentTexts];
+                            restoredTexts.splice(Math.min(index, restoredTexts.length), 0, text);
+                            onChange(slide.id, { extraTexts: restoredTexts });
+                          });
+                        }}
+                        className="flex size-8 items-center justify-center rounded text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
                       >
                         <Cancel01Icon size={12} />
                       </button>
@@ -889,7 +958,7 @@ export function StoreSlidePanel({
                 </div>
               </div>
             </Section>
-            <Section title="Screenshot" compact>
+            <Section title={isDuo ? `${screenLabel} image` : "Screenshot"} compact>
               {isDuo ? (
                 <div className="grid grid-cols-2 gap-2">
                     <label className="flex min-w-0 items-center gap-1.5 text-[10px] text-muted-foreground">
@@ -927,7 +996,7 @@ export function StoreSlidePanel({
                 </div>
               ) : null}
               <Button variant="outline" size="sm" className="w-full text-xs" onClick={() => replaceInputRef.current?.click()}>
-                <Image01Icon size={14} /> Replace image
+                <Image01Icon size={14} /> {screenSlide.src ? `Replace ${screenImageLabel}` : `Upload ${screenImageLabel}`}
               </Button>
               <input
                 ref={replaceInputRef}
@@ -936,18 +1005,18 @@ export function StoreSlidePanel({
                 className="hidden"
                 onChange={(event) => {
                   const file = event.target.files?.[0];
-                  if (file) onReplace(file);
+                  if (file) onReplace(screenSlide.id, file);
                   event.currentTarget.value = "";
                 }}
               />
-              {usesDeviceFrame ? (
+              {screenSlide.src && usesDeviceFrame ? (
                 <>
                   <div className="flex items-center justify-between gap-3 border-t border-foreground/10 pt-3">
                     <span className="text-[10px] font-medium text-muted-foreground">Image framing</span>
                     <button
                       type="button"
                       disabled={!imageFramingChanged}
-                      onClick={() => update({ image: { ...DEFAULT_IMAGE_TRANSFORM } })}
+                      onClick={() => onChange(screenSlide.id, { image: { ...DEFAULT_IMAGE_TRANSFORM } })}
                       className="rounded px-1.5 py-1 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.05] hover:text-foreground disabled:pointer-events-none disabled:opacity-35"
                     >
                       Reset
@@ -956,12 +1025,11 @@ export function StoreSlidePanel({
                   <SegmentedControl
                     size="sm"
                     value={imageMode}
-                    onChange={(value) => update({
-                      image: {
-                        ...slide.image,
-                        mode: value as StoreSlide["image"]["mode"],
-                      },
-                    })}
+                    onChange={(value) => {
+                      const mode = value as StoreSlide["image"]["mode"];
+                      if (mode === "custom") onCropRequest(screenSlide.id, screenSlide.image);
+                      onChange(screenSlide.id, { image: { ...screenSlide.image, mode } });
+                    }}
                     options={[
                       { id: "fill", label: "Fill" },
                       { id: "fit", label: "Fit" },
@@ -973,14 +1041,18 @@ export function StoreSlidePanel({
                       ? "Fills the screen edge to edge. Some image edges may be cropped."
                       : imageMode === "fit"
                         ? "Shows the complete image at its original aspect ratio."
-                        : "Adjust the image scale and crop position manually."}
+                        : "Drag and zoom directly on the canvas to frame the screen."}
                   </p>
                   {imageMode === "custom" ? (
-                    <div className="space-y-3 rounded-md border border-foreground/10 bg-foreground/[0.025] p-2.5">
-                      <RangeControl label="Scale" value={slide.image.scale} min={0.25} max={4} step={0.01} suffix="×" onChange={(scale) => update({ image: { ...slide.image, mode: "custom", scale } })} />
-                      <RangeControl label="Horizontal" value={slide.image.offsetX} min={-100} max={100} suffix="%" onChange={(offsetX) => update({ image: { ...slide.image, mode: "custom", offsetX } })} />
-                      <RangeControl label="Vertical" value={slide.image.offsetY} min={-100} max={100} suffix="%" onChange={(offsetY) => update({ image: { ...slide.image, mode: "custom", offsetY } })} />
-                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="w-full text-xs"
+                      onClick={() => onCropRequest(screenSlide.id, screenSlide.image)}
+                    >
+                      Edit crop on canvas
+                    </Button>
                   ) : null}
                 </>
               ) : null}
@@ -991,9 +1063,9 @@ export function StoreSlidePanel({
         {tab === "advanced" ? (
           <div className="space-y-1">
             <Section title="Image adjustments" compact>
-              <RangeControl label="Brightness" value={slide.filters.brightness} min={50} max={150} suffix="%" onChange={(brightness) => update({ filters: { ...slide.filters, brightness } })} />
-              <RangeControl label="Contrast" value={slide.filters.contrast} min={50} max={150} suffix="%" onChange={(contrast) => update({ filters: { ...slide.filters, contrast } })} />
-              <RangeControl label="Saturation" value={slide.filters.saturation} min={0} max={180} suffix="%" onChange={(saturation) => update({ filters: { ...slide.filters, saturation } })} />
+              <RangeControl label="Brightness" value={screenSlide.filters.brightness} min={50} max={150} suffix="%" onChange={(brightness) => onChange(screenSlide.id, { filters: { ...screenSlide.filters, brightness } })} />
+              <RangeControl label="Contrast" value={screenSlide.filters.contrast} min={50} max={150} suffix="%" onChange={(contrast) => onChange(screenSlide.id, { filters: { ...screenSlide.filters, contrast } })} />
+              <RangeControl label="Saturation" value={screenSlide.filters.saturation} min={0} max={180} suffix="%" onChange={(saturation) => onChange(screenSlide.id, { filters: { ...screenSlide.filters, saturation } })} />
             </Section>
             <Section title="3D perspective" compact>
               <RangeControl label="Tilt X" value={slide.device.rotateX} min={-25} max={25} suffix="°" onChange={(rotateX) => update({ device: { ...slide.device, rotateX } })} />
@@ -1009,13 +1081,17 @@ export function StoreSlidePanel({
                       type="button"
                       aria-label="Remove overlay"
                       onClick={() => {
+                        const deletedOverlay = slide.overlay;
                         overlayRequestIdsRef.current.set(
                           slide.id,
                           (overlayRequestIdsRef.current.get(slide.id) ?? 0) + 1,
                         );
                         update({ overlay: null });
+                        showStoreUndoToast("Overlay removed", () => {
+                          onChange(slide.id, { overlay: deletedOverlay });
+                        });
                       }}
-                      className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                      className="flex size-8 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40"
                     >
                       <Cancel01Icon size={14} />
                     </button>

--- a/components/store-screenshots/StoreSlideCanvas.tsx
+++ b/components/store-screenshots/StoreSlideCanvas.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { DeviceShell } from "@/components/mockups/DeviceShell";
+import { CropGridOverlay, DeviceShell } from "@/components/mockups/DeviceShell";
 import { getMockupDefinition } from "@/lib/constants/mockups";
 import { backgroundToCss } from "@/lib/store-screenshots/config";
 import { composeStoreSlide, resolveStoreLayout } from "@/lib/store-screenshots/layouts";
@@ -14,6 +14,7 @@ import type {
   StoreDeviceSlot,
   StoreDeviceStyle,
   StoreDeviceTransform,
+  StoreImageTransform,
   StoreOutputProfile,
   StoreProject,
   StoreSlide,
@@ -58,6 +59,25 @@ interface DeviceInteractionState {
   origin: StoreDeviceTransform;
 }
 
+interface ScreenCropSession {
+  slot: StoreDeviceSlot;
+  sourceSlideId: string;
+  original: StoreImageTransform;
+}
+
+interface ScreenCropDragState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  origin: StoreImageTransform;
+}
+
+export interface StoreCropRequest {
+  id: number;
+  sourceSlideId: string;
+  original: StoreImageTransform;
+}
+
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value));
 
@@ -69,6 +89,7 @@ function useImageAspectRatio(src: string, fallback: number): number {
   );
 
   React.useEffect(() => {
+    if (!src) return;
     const cached = imageAspectRatioCache.get(src);
     if (cached) {
       setAspectRatio(cached);
@@ -117,15 +138,78 @@ function screenContent(slide: StoreSlide): DeviceScreenContent {
   };
 }
 
-function ScreenOnly({ slide }: { slide: StoreSlide }): React.JSX.Element {
+function ScreenOnly({
+  slide,
+  interactive = false,
+  onFile,
+}: {
+  slide: StoreSlide;
+  interactive?: boolean;
+  onFile?: (file: File) => void;
+}): React.JSX.Element {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const content = screenContent(slide);
+
+  if (!slide.src && interactive) {
+    return (
+      <div
+        className="pointer-events-auto relative h-full w-full overflow-hidden rounded-[2cqw] border border-dashed border-foreground/25 bg-background/55 shadow-sm backdrop-blur-sm"
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          event.dataTransfer.dropEffect = "copy";
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const file = Array.from(event.dataTransfer.files).find((item) => item.type.startsWith("image/"));
+          if (file) onFile?.(file);
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Upload a new screen image"
+          onClick={() => inputRef.current?.click()}
+          className="flex h-full w-full flex-col items-center justify-center gap-[2cqw] px-[8%] text-center text-foreground/65 transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-foreground/30"
+        >
+          <span className="flex size-[8cqw] min-h-8 min-w-8 items-center justify-center rounded-full border border-foreground/15 bg-background shadow-sm">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </span>
+          <span className="text-[clamp(9px,2.2cqw,14px)] font-medium leading-tight">Upload screen image</span>
+          <span className="text-[clamp(7px,1.5cqw,11px)] leading-tight text-muted-foreground">Click or drop an image here</span>
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) onFile?.(file);
+            event.currentTarget.value = "";
+          }}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="relative h-full w-full overflow-hidden">
-      <img
-        src={slide.src}
-        alt=""
-        draggable={false}
-        className="block h-full w-full select-none object-contain"
-      />
+      {slide.src ? (
+        <img
+          src={slide.src}
+          alt=""
+          draggable={false}
+          className="block h-full w-full select-none"
+          style={{
+            objectFit: content.fit,
+            transform: `translate(${content.offset.x}%, ${content.offset.y}%) scale(${content.scale})`,
+            transformOrigin: "center",
+          }}
+        />
+      ) : null}
     </div>
   );
 }
@@ -133,13 +217,41 @@ function ScreenOnly({ slide }: { slide: StoreSlide }): React.JSX.Element {
 function StoreDevice({
   slide,
   style,
+  interactive = false,
+  cropping = false,
+  onScreenFile,
+  onScreenPointerDown,
+  onScreenPointerMove,
+  onScreenPointerUp,
+  onScreenPointerCancel,
+  onScreenKeyDown,
 }: {
   slide: StoreSlide;
   style: StoreDeviceStyle;
+  interactive?: boolean;
+  cropping?: boolean;
+  onScreenFile?: (file: File) => void;
+  onScreenPointerDown?: React.PointerEventHandler<HTMLDivElement>;
+  onScreenPointerMove?: React.PointerEventHandler<HTMLDivElement>;
+  onScreenPointerUp?: React.PointerEventHandler<HTMLDivElement>;
+  onScreenPointerCancel?: React.PointerEventHandler<HTMLDivElement>;
+  onScreenKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
 }): React.JSX.Element {
   const definition = resolveDeviceDefinition(style);
-  if (!definition) return <ScreenOnly slide={slide} />;
-  return <DeviceShell definition={definition} screen={screenContent(slide)} />;
+  if (!definition) return <ScreenOnly slide={slide} interactive={interactive} onFile={onScreenFile} />;
+  return (
+    <DeviceShell
+      definition={definition}
+      screen={screenContent(slide)}
+      editing={cropping}
+      onScreenFile={interactive ? onScreenFile : undefined}
+      onScreenPointerDown={cropping ? onScreenPointerDown : undefined}
+      onScreenPointerMove={cropping ? onScreenPointerMove : undefined}
+      onScreenPointerUp={cropping ? onScreenPointerUp : undefined}
+      onScreenPointerCancel={cropping ? onScreenPointerCancel : undefined}
+      onScreenKeyDown={cropping ? onScreenKeyDown : undefined}
+    />
+  );
 }
 
 export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
@@ -154,6 +266,11 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
   onSlideChange,
   onDeviceSelect,
   selectedDeviceSlot,
+  onScreenFile,
+  onScreenDelete,
+  onScreenImageChange,
+  cropRequest,
+  onTextEditRequest,
 }: {
   project: StoreProject;
   slide: StoreSlide;
@@ -166,10 +283,19 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
   onSlideChange?: (slide: StoreSlide) => void;
   onDeviceSelect?: (slot: StoreDeviceSlot | null) => void;
   selectedDeviceSlot?: StoreDeviceSlot | null;
+  onScreenFile?: (sourceSlideId: string, file: File) => void;
+  onScreenDelete?: (sourceSlideId: string) => void;
+  onScreenImageChange?: (sourceSlideId: string, image: StoreImageTransform) => void;
+  cropRequest?: StoreCropRequest | null;
+  onTextEditRequest?: (field: "heading" | "subheading") => void;
 }): React.JSX.Element {
   const canvasRef = React.useRef<HTMLDivElement>(null);
   const dragRef = React.useRef<TextDragState | null>(null);
+  const textPointerMovedRef = React.useRef(false);
   const deviceInteractionRef = React.useRef<DeviceInteractionState | null>(null);
+  const screenCropDragRef = React.useRef<ScreenCropDragState | null>(null);
+  const handledCropRequestRef = React.useRef(0);
+  const [screenCropSession, setScreenCropSession] = React.useState<ScreenCropSession | null>(null);
   const layoutId = resolveStoreLayout(project.templateId, slideIndex, slide.layoutOverride);
   const composition = composeStoreSlide(layoutId);
   const defaultDeviceStyle = project.theme.deviceStyle;
@@ -192,6 +318,32 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
   const primaryImageAspect = useImageAspectRatio(primarySlide.src, fallbackScreenAspect);
   const secondaryImageAspect = useImageAspectRatio(secondarySlide.src, fallbackScreenAspect);
 
+  React.useEffect(() => {
+    if (!screenCropSession) return;
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      onScreenImageChange?.(screenCropSession.sourceSlideId, screenCropSession.original);
+      setScreenCropSession(null);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onScreenImageChange, screenCropSession]);
+
+  React.useEffect(() => {
+    if (!cropRequest || handledCropRequestRef.current === cropRequest.id) return;
+    const slot = primarySlide.id === cropRequest.sourceSlideId
+      ? "primary"
+      : secondarySlide.id === cropRequest.sourceSlideId ? "secondary" : null;
+    if (!slot) return;
+    handledCropRequestRef.current = cropRequest.id;
+    onDeviceSelect?.(slot);
+    setScreenCropSession({
+      slot,
+      sourceSlideId: cropRequest.sourceSlideId,
+      original: cropRequest.original,
+    });
+  }, [cropRequest, onDeviceSelect, primarySlide.id, secondarySlide.id]);
+
   const beginTextDrag = (
     event: React.PointerEvent<HTMLElement>,
     target: TextDragTarget,
@@ -200,6 +352,7 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
     event.preventDefault();
     event.stopPropagation();
     onDeviceSelect?.(null);
+    textPointerMovedRef.current = false;
     event.currentTarget.setPointerCapture(event.pointerId);
     dragRef.current = {
       pointerId: event.pointerId,
@@ -211,6 +364,93 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
 
   const selectDevice = (slot: StoreDeviceSlot): void => {
     onDeviceSelect?.(slot);
+  };
+
+  const startScreenCrop = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    slot: StoreDeviceSlot,
+    source: StoreSlide,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!onScreenImageChange) return;
+    selectDevice(slot);
+    setScreenCropSession({ slot, sourceSlideId: source.id, original: source.image });
+    if (source.image.mode !== "custom") {
+      onScreenImageChange(source.id, {
+        ...source.image,
+        mode: "custom",
+        scale: Math.max(1, source.image.scale),
+        offsetX: 0,
+        offsetY: 0,
+      });
+    }
+  };
+
+  const beginScreenCropDrag = (
+    event: React.PointerEvent<HTMLElement>,
+    image: StoreImageTransform,
+  ): void => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    screenCropDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      origin: image,
+    };
+  };
+
+  const moveScreenCropDrag = (
+    event: React.PointerEvent<HTMLElement>,
+    sourceSlideId: string,
+  ): void => {
+    const drag = screenCropDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId || !onScreenImageChange) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const bounds = event.currentTarget.getBoundingClientRect();
+    if (bounds.width === 0 || bounds.height === 0) return;
+    onScreenImageChange(sourceSlideId, {
+      ...drag.origin,
+      mode: "custom",
+      offsetX: clamp(drag.origin.offsetX + ((event.clientX - drag.startX) / bounds.width) * 100, -100, 100),
+      offsetY: clamp(drag.origin.offsetY + ((event.clientY - drag.startY) / bounds.height) * 100, -100, 100),
+    });
+  };
+
+  const endScreenCropDrag = (event: React.PointerEvent<HTMLElement>): void => {
+    if (screenCropDragRef.current?.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    screenCropDragRef.current = null;
+  };
+
+  const moveScreenCropWithKeyboard = (
+    event: React.KeyboardEvent<HTMLElement>,
+    source: StoreSlide,
+  ): void => {
+    if (!onScreenImageChange) return;
+    if (event.key === "Escape" && screenCropSession?.sourceSlideId === source.id) {
+      event.preventDefault();
+      onScreenImageChange(source.id, screenCropSession.original);
+      setScreenCropSession(null);
+      return;
+    }
+    const amount = event.shiftKey ? 5 : 1;
+    const deltaX = event.key === "ArrowLeft" ? -amount : event.key === "ArrowRight" ? amount : 0;
+    const deltaY = event.key === "ArrowUp" ? -amount : event.key === "ArrowDown" ? amount : 0;
+    if (deltaX === 0 && deltaY === 0) return;
+    event.preventDefault();
+    onScreenImageChange(source.id, {
+      ...source.image,
+      mode: "custom",
+      offsetX: clamp(source.image.offsetX + deltaX, -100, 100),
+      offsetY: clamp(source.image.offsetY + deltaY, -100, 100),
+    });
   };
 
   const beginDeviceInteraction = (
@@ -369,6 +609,9 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
     event.preventDefault();
     event.stopPropagation();
     const bounds = canvas.getBoundingClientRect();
+    if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) > 3) {
+      textPointerMovedRef.current = true;
+    }
     const deltaX = ((event.clientX - drag.startX) / bounds.width) * 100;
     const deltaY = ((event.clientY - drag.startY) / bounds.height) * 100;
 
@@ -403,6 +646,14 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
     dragRef.current = null;
+  };
+
+  const editTextOnClick = (field: "heading" | "subheading"): void => {
+    if (textPointerMovedRef.current) {
+      textPointerMovedRef.current = false;
+      return;
+    }
+    onTextEditRequest?.(field);
   };
 
   const moveTextWithKeyboard = (
@@ -506,12 +757,20 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
               role={interactive ? "button" : undefined}
               tabIndex={interactive ? 0 : undefined}
               aria-label={interactive ? "Move heading" : undefined}
-              title={interactive ? "Drag to reposition heading" : undefined}
+              title={interactive ? "Click to edit; drag to reposition heading" : undefined}
               onPointerDown={(event) => beginTextDrag(event, { kind: "heading", origin: headingOffset })}
               onPointerMove={moveDraggedText}
               onPointerUp={endTextDrag}
               onPointerCancel={endTextDrag}
-              onKeyDown={(event) => moveTextWithKeyboard(event, "heading")}
+              onClick={() => editTextOnClick("heading")}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onTextEditRequest?.("heading");
+                  return;
+                }
+                moveTextWithKeyboard(event, "heading");
+              }}
               className={cn(interactiveTextClass, "whitespace-pre-line text-balance font-semibold tracking-[-0.04em]")}
               style={{
                 color: headlineColor,
@@ -529,12 +788,20 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
               role={interactive ? "button" : undefined}
               tabIndex={interactive ? 0 : undefined}
               aria-label={interactive ? "Move subheading" : undefined}
-              title={interactive ? "Drag to reposition subheading" : undefined}
+              title={interactive ? "Click to edit; drag to reposition subheading" : undefined}
               onPointerDown={(event) => beginTextDrag(event, { kind: "subheading", origin: subheadingOffset })}
               onPointerMove={moveDraggedText}
               onPointerUp={endTextDrag}
               onPointerCancel={endTextDrag}
-              onKeyDown={(event) => moveTextWithKeyboard(event, "subheading")}
+              onClick={() => editTextOnClick("subheading")}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onTextEditRequest?.("subheading");
+                  return;
+                }
+                moveTextWithKeyboard(event, "subheading");
+              }}
               className={cn(interactiveTextClass, "text-pretty font-medium tracking-[-0.015em]")}
               style={{
                 color: subheadingColor,
@@ -604,7 +871,10 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
         const adjustedWidth = device.width * transform.scale;
         const movementLimit = resolvedDeviceStyle === "screen-only" ? 100 : 25;
         const deviceKey = `${slide.id}-${device.source}-${index}`;
-        const selected = interactive && selectedDeviceSlot === slot;
+        const emptyScreen = !definition && !source.src;
+        const selected = interactive && selectedDeviceSlot === slot && !emptyScreen;
+        const cropping = screenCropSession?.slot === slot
+          && screenCropSession.sourceSlideId === source.id;
         const objectLabel = layoutId === "duo"
           ? `${device.source === "primary" ? "left" : "right"} ${definition ? "device" : "screen"}`
           : definition ? "device" : "screen";
@@ -642,16 +912,40 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
                   ].filter(Boolean).join(" "),
                 }}
               >
-                <StoreDevice slide={source} style={resolvedDeviceStyle} />
+                <StoreDevice
+                  slide={source}
+                  style={resolvedDeviceStyle}
+                  interactive={interactive}
+                  cropping={cropping}
+                  onScreenFile={(file) => onScreenFile?.(source.id, file)}
+                  onScreenPointerDown={(event) => beginScreenCropDrag(event, source.image)}
+                  onScreenPointerMove={(event) => moveScreenCropDrag(event, source.id)}
+                  onScreenPointerUp={endScreenCropDrag}
+                  onScreenPointerCancel={endScreenCropDrag}
+                  onScreenKeyDown={(event) => moveScreenCropWithKeyboard(event, source)}
+                />
               </div>
 
-              {interactive ? (
+              {interactive && !emptyScreen && !cropping ? (
                 <button
                   type="button"
                   data-store-device-control="move"
                   aria-label={`Move ${objectLabel}`}
                   title={`Click to select ${objectLabel}; drag to move`}
                   onFocus={() => selectDevice(slot)}
+                  onDragOver={(event) => {
+                    if (!event.dataTransfer.types.includes("Files")) return;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.dataTransfer.dropEffect = "copy";
+                  }}
+                  onDrop={(event) => {
+                    const file = Array.from(event.dataTransfer.files).find((item) => item.type.startsWith("image/"));
+                    if (!file) return;
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onScreenFile?.(source.id, file);
+                  }}
                   onPointerDown={(event) => beginDeviceInteraction(event, "move", slot, transform, movementLimit)}
                   onPointerMove={moveDeviceInteraction}
                   onPointerUp={endDeviceInteraction}
@@ -661,7 +955,82 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
                 />
               ) : null}
 
-              {selected ? (
+              {selected && cropping ? (
+                <>
+                  {!definition ? (
+                    <div
+                      data-store-device-control="crop-image"
+                      role="group"
+                      tabIndex={0}
+                      aria-label={`Reposition ${objectLabel} crop`}
+                      aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight Escape"
+                      title="Drag to reposition the image inside the crop"
+                      onPointerDown={(event) => beginScreenCropDrag(event, source.image)}
+                      onPointerMove={(event) => moveScreenCropDrag(event, source.id)}
+                      onPointerUp={endScreenCropDrag}
+                      onPointerCancel={endScreenCropDrag}
+                      onKeyDown={(event) => moveScreenCropWithKeyboard(event, source)}
+                      className="pointer-events-auto absolute inset-0 z-30 cursor-move touch-none select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background"
+                    >
+                      <CropGridOverlay />
+                    </div>
+                  ) : null}
+                  <div className={cn(
+                    "pointer-events-auto absolute left-1/2 z-40 flex h-10 -translate-x-1/2 items-center gap-0.5 rounded-full border border-foreground/15 bg-background/95 p-1 text-foreground shadow-lg backdrop-blur-sm",
+                    definition ? "top-2" : "-top-14",
+                  )}>
+                    <button
+                      type="button"
+                      aria-label="Zoom image out"
+                      title="Zoom out"
+                      onClick={() => onScreenImageChange?.(source.id, {
+                        ...source.image,
+                        mode: "custom",
+                        scale: Math.round(clamp(source.image.scale - 0.1, 0.25, 4) * 100) / 100,
+                      })}
+                      className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/[0.07] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30"
+                    >
+                      <span aria-hidden="true">−</span>
+                    </button>
+                    <span className="min-w-9 text-center text-[10px] tabular-nums text-muted-foreground">
+                      {Math.round(source.image.scale * 100)}%
+                    </span>
+                    <button
+                      type="button"
+                      aria-label="Zoom image in"
+                      title="Zoom in"
+                      onClick={() => onScreenImageChange?.(source.id, {
+                        ...source.image,
+                        mode: "custom",
+                        scale: Math.round(clamp(source.image.scale + 0.1, 0.25, 4) * 100) / 100,
+                      })}
+                      className="flex size-8 items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/[0.07] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30"
+                    >
+                      <span aria-hidden="true">+</span>
+                    </button>
+                    <span aria-hidden="true" className="mx-0.5 h-4 w-px bg-foreground/10" />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onScreenImageChange?.(source.id, screenCropSession.original);
+                        setScreenCropSession(null);
+                      }}
+                      className="min-h-8 rounded-full px-2.5 py-1 text-[10px] font-medium text-muted-foreground hover:bg-foreground/[0.07] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/30"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setScreenCropSession(null)}
+                      className="min-h-8 rounded-full bg-foreground px-2.5 py-1 text-[10px] font-medium text-background hover:opacity-85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/40"
+                    >
+                      Done
+                    </button>
+                  </div>
+                </>
+              ) : null}
+
+              {selected && !cropping ? (
                 <>
                   {(["top-left", "top-right", "bottom-left", "bottom-right"] as const).map((handle) => (
                     <button
@@ -676,7 +1045,7 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
                       onPointerCancel={endDeviceInteraction}
                       onKeyDown={(event) => resizeDeviceWithKeyboard(event, slot, transform)}
                       className={cn(
-                        "pointer-events-auto absolute z-30 size-3 rounded-[2px] border-2 border-[var(--canvas-selection)] bg-[var(--canvas-control-surface)] shadow-sm before:absolute before:-inset-2 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--canvas-selection)]",
+                        "pointer-events-auto absolute z-30 size-3 rounded-[2px] border-2 border-[var(--canvas-selection)] bg-[var(--canvas-control-surface)] shadow-sm before:absolute before:-inset-3.5 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--canvas-selection)]",
                         handle.includes("top") ? "-top-1.5" : "-bottom-1.5",
                         handle.includes("left") ? "-left-1.5" : "-right-1.5",
                         handle === "top-left" || handle === "bottom-right" ? "cursor-nwse-resize" : "cursor-nesw-resize",
@@ -697,13 +1066,46 @@ export const StoreSlideCanvas = React.memo(function StoreSlideCanvas({
                     onPointerUp={endDeviceInteraction}
                     onPointerCancel={endDeviceInteraction}
                     onKeyDown={(event) => rotateDeviceWithKeyboard(event, slot, transform)}
-                    className="pointer-events-auto absolute -top-11 left-1/2 z-30 flex size-6 -translate-x-1/2 cursor-grab touch-none select-none items-center justify-center rounded-full border-2 border-[var(--canvas-selection)] bg-[var(--canvas-control-surface)] text-[var(--canvas-selection)] shadow-sm before:absolute before:-inset-1.5 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--canvas-selection)] active:cursor-grabbing"
+                    className="pointer-events-auto absolute -top-12 left-1/2 z-30 flex size-8 -translate-x-1/2 cursor-grab touch-none select-none items-center justify-center rounded-full border-2 border-[var(--canvas-selection)] bg-[var(--canvas-control-surface)] text-[var(--canvas-selection)] shadow-sm before:absolute before:-inset-1 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--canvas-selection)] active:cursor-grabbing"
                   >
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                       <path d="M21.5 2v6h-6" />
                       <path d="M21.34 13.72A10 10 0 1 1 18.57 4.62L21.5 8" />
                     </svg>
                   </button>
+                  {!definition && source.src ? (
+                    <>
+                      <button
+                        type="button"
+                        data-store-device-control="start-crop"
+                        aria-label={`Crop ${objectLabel} image`}
+                        title={`Crop ${objectLabel} image`}
+                        onClick={(event) => startScreenCrop(event, slot, source)}
+                        className="pointer-events-auto absolute -top-12 left-1/2 z-30 flex size-8 -translate-x-14 items-center justify-center rounded-full border-2 border-[var(--canvas-selection)] bg-[var(--canvas-control-surface)] text-[var(--canvas-selection)] shadow-sm before:absolute before:-inset-1 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--canvas-selection)]"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                          <path d="M6 2v14a2 2 0 0 0 2 2h14" />
+                          <path d="M2 6h14a2 2 0 0 1 2 2v14" />
+                        </svg>
+                      </button>
+                      <button
+                        type="button"
+                        data-store-device-control="delete-screen"
+                        aria-label={`Delete ${objectLabel} image`}
+                        title={`Delete ${objectLabel} image`}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          onScreenDelete?.(source.id);
+                        }}
+                        className="pointer-events-auto absolute -top-12 left-1/2 z-30 flex size-8 translate-x-6 items-center justify-center rounded-full border-2 border-destructive bg-[var(--canvas-control-surface)] text-destructive shadow-sm before:absolute before:-inset-1 before:content-[''] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50"
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true">
+                          <path d="M6 6l12 12M18 6L6 18" />
+                        </svg>
+                      </button>
+                    </>
+                  ) : null}
                 </>
               ) : null}
             </div>

--- a/components/store-screenshots/store-undo-toast.ts
+++ b/components/store-screenshots/store-undo-toast.ts
@@ -1,0 +1,14 @@
+import { toast } from "sonner";
+
+const STORE_UNDO_DURATION_MS = 8_000;
+
+export function showStoreUndoToast(title: string, onUndo: () => void): void {
+  toast(title, {
+    description: "You can restore it for the next 8 seconds.",
+    duration: STORE_UNDO_DURATION_MS,
+    action: {
+      label: "Undo",
+      onClick: onUndo,
+    },
+  });
+}

--- a/lib/store-screenshots/history.ts
+++ b/lib/store-screenshots/history.ts
@@ -1,0 +1,119 @@
+import {
+  MAX_STORE_PROJECT_IMAGE_BYTES,
+  storeDataUrlBytes,
+} from "./project";
+import type { StoreProject } from "./types";
+
+export const MAX_STORE_HISTORY_ENTRIES = 30;
+
+function projectImageSources(project: StoreProject): string[] {
+  return project.slides.flatMap((slide) => [
+    slide.src,
+    slide.backgroundImageOverride?.src,
+    slide.overlay?.src,
+  ].filter((source): source is string => Boolean(source)));
+}
+
+export function appendStoreHistory(
+  stack: StoreProject[],
+  snapshot: StoreProject,
+  activeProject: StoreProject,
+  imageBudgetBytes = MAX_STORE_PROJECT_IMAGE_BYTES,
+): StoreProject[] {
+  const candidates = [...stack, snapshot].slice(-MAX_STORE_HISTORY_ENTRIES);
+  const seenSources = new Set(projectImageSources(activeProject));
+  const retained: StoreProject[] = [];
+  let retainedImageBytes = 0;
+
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index];
+    const newSources = projectImageSources(candidate).filter((source) => !seenSources.has(source));
+    const newImageBytes = newSources.reduce(
+      (total, source) => total + storeDataUrlBytes(source),
+      0,
+    );
+    if (retainedImageBytes + newImageBytes > imageBudgetBytes) break;
+    newSources.forEach((source) => seenSources.add(source));
+    retainedImageBytes += newImageBytes;
+    retained.push(candidate);
+  }
+
+  return retained.reverse();
+}
+
+function collectChangedPaths(
+  previous: unknown,
+  next: unknown,
+  path: string,
+  paths: string[],
+): void {
+  if (Object.is(previous, next)) return;
+  if (
+    previous === null
+    || next === null
+    || typeof previous !== "object"
+    || typeof next !== "object"
+  ) {
+    paths.push(path);
+    return;
+  }
+
+  if (Array.isArray(previous) || Array.isArray(next)) {
+    if (!Array.isArray(previous) || !Array.isArray(next) || previous.length !== next.length) {
+      paths.push(path);
+      return;
+    }
+    for (let index = 0; index < previous.length; index += 1) {
+      const previousItem = previous[index];
+      const nextItem = next[index];
+      const itemId = (
+        previousItem
+        && nextItem
+        && typeof previousItem === "object"
+        && typeof nextItem === "object"
+        && "id" in previousItem
+        && "id" in nextItem
+        && previousItem.id === nextItem.id
+        && typeof previousItem.id === "string"
+      ) ? previousItem.id : String(index);
+      collectChangedPaths(previousItem, nextItem, `${path}.${itemId}`, paths);
+    }
+    return;
+  }
+
+  const previousRecord = previous as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
+  const keys = new Set([...Object.keys(previousRecord), ...Object.keys(nextRecord)]);
+  keys.forEach((key) => {
+    collectChangedPaths(previousRecord[key], nextRecord[key], path ? `${path}.${key}` : key, paths);
+  });
+}
+
+export function storeHistoryGroupKey(
+  previous: StoreProject,
+  next: StoreProject,
+): string | null {
+  const paths: string[] = [];
+  collectChangedPaths(previous, next, "", paths);
+  const meaningfulPaths = paths.filter((path) => path !== "updatedAt");
+  if (meaningfulPaths.length === 0) return null;
+  if (meaningfulPaths.some((path) => (
+    path === "slides"
+    || path === "templateId"
+    || path === "createdAt"
+    || path === "selectedSlideId"
+    || path.endsWith(".src")
+    || path.includes(".backgroundImageOverride")
+    || path.includes(".overlay.src")
+  ))) return null;
+  if (meaningfulPaths.length === 1) return meaningfulPaths[0];
+
+  const segments = meaningfulPaths.map((path) => path.split("."));
+  const common: string[] = [];
+  for (let index = 0; index < segments[0].length; index += 1) {
+    const segment = segments[0][index];
+    if (segments.every((parts) => parts[index] === segment)) common.push(segment);
+    else break;
+  }
+  return common.length >= 3 ? common.join(".") : null;
+}

--- a/tests/store-screenshots.test.ts
+++ b/tests/store-screenshots.test.ts
@@ -8,6 +8,11 @@ import {
 } from "../lib/store-screenshots/config";
 import { composeStoreSlide, resolveStoreLayout } from "../lib/store-screenshots/layouts";
 import {
+  appendStoreHistory,
+  MAX_STORE_HISTORY_ENTRIES,
+  storeHistoryGroupKey,
+} from "../lib/store-screenshots/history";
+import {
   assertStoreImageBudget,
   assertStoreImageFile,
   createScratchStoreProject,
@@ -60,6 +65,87 @@ test("App Store projects cap slides at the supported maximum", () => {
 
   assert.equal(project.slides.length, MAX_STORE_SLIDES);
   assert.equal(project.selectedSlideId, project.slides[0].id);
+});
+
+test("store history caps retained image data instead of retaining every replacement", () => {
+  const projectWithImage = (src: string, name: string) => createStoreProject([
+    createStoreSlide(`data:image/png;base64,${src}`, name),
+  ]);
+  const active = projectWithImage("DDDD", "active.png");
+  const oldest = projectWithImage("AAAA", "oldest.png");
+  const middle = projectWithImage("BBBB", "middle.png");
+  const newest = projectWithImage("CCCC", "newest.png");
+
+  const history = appendStoreHistory(
+    appendStoreHistory(
+      appendStoreHistory([], oldest, active, 6),
+      middle,
+      active,
+      6,
+    ),
+    newest,
+    active,
+    6,
+  );
+
+  assert.deepEqual(history.map((project) => project.slides[0].name), [
+    "middle.png",
+    "newest.png",
+  ]);
+});
+
+test("store history keeps lightweight edits while enforcing its entry limit", () => {
+  const active = createScratchStoreProject();
+  let history: ReturnType<typeof appendStoreHistory> = [];
+  for (let index = 0; index < MAX_STORE_HISTORY_ENTRIES + 5; index += 1) {
+    history = appendStoreHistory(history, { ...active, updatedAt: index }, active);
+  }
+
+  assert.equal(history.length, MAX_STORE_HISTORY_ENTRIES);
+  assert.equal(history[0].updatedAt, 5);
+});
+
+test("store history groups only repeated edits to the same field", () => {
+  const project = createScratchStoreProject();
+  const slide = project.slides[0];
+  const shadowEdit = {
+    ...project,
+    theme: { ...project.theme, shadow: project.theme.shadow + 1 },
+    updatedAt: project.updatedAt + 1,
+  };
+  const headlineEdit = {
+    ...project,
+    slides: project.slides.map((candidate) => candidate.id === slide.id
+      ? { ...candidate, headline: "Updated" }
+      : candidate),
+    updatedAt: project.updatedAt + 1,
+  };
+  const imageReplacement = {
+    ...project,
+    slides: project.slides.map((candidate) => candidate.id === slide.id
+      ? { ...candidate, src: "data:image/png;base64,AAAA", name: "replacement.png" }
+      : candidate),
+  };
+  const deviceMove = {
+    ...project,
+    slides: project.slides.map((candidate) => candidate.id === slide.id
+      ? {
+          ...candidate,
+          device: {
+            ...candidate.device,
+            offsetX: candidate.device.offsetX + 1,
+            offsetY: candidate.device.offsetY + 1,
+          },
+        }
+      : candidate),
+    updatedAt: project.updatedAt + 1,
+  };
+
+  assert.equal(storeHistoryGroupKey(project, shadowEdit), "theme.shadow");
+  assert.equal(storeHistoryGroupKey(project, headlineEdit), `slides.${slide.id}.headline`);
+  assert.equal(storeHistoryGroupKey(project, deviceMove), `slides.${slide.id}.device`);
+  assert.equal(storeHistoryGroupKey(project, imageReplacement), null);
+  assert.equal(storeHistoryGroupKey(project, { ...project, slides: [] }), null);
 });
 
 test("a new Store Screenshots visit offers a complete editable starter set", () => {


### PR DESCRIPTION
 ## Summary

  - Add memory-bounded undo/redo history for store screenshot projects.
  - Group related edits while keeping unrelated actions as separate undo steps.
  - Prevent stale delete Undo actions from restoring content after Start over or template changes.
  - Clear history correctly when applying templates.
  - Consolidate crop overlays and delete/undo toast logic.
  - Improve crop keyboard accessibility and replace hardcoded crop colors with theme tokens.

  ## Production safety

  - History retains at most 30 entries with a bounded image-data budget.
  - Image replacements no longer accumulate unbounded snapshots.
  - Project generation guards prevent stale asynchronous restoration.
  - Drag operations remain grouped into a single undo action.

  ## Verification

  - `npm test` — 90 tests passed.
  - `npx tsc --noEmit` — passed.
  - `npm run lint` — zero errors.
  - `npm run build` — passed.
  - Chrome smoke test:
    - Undo and Redo
    - Crop keyboard movement
    - Escape restores the original crop
    - No new feature-related console errors
 